### PR TITLE
add windows-installer example pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Virt-sysprep can be used for preparing VM images which can be then used as base 
 This example shows how you can update an operating system and seal VM's image by using virt-customize.
 Then, a VM is created from such image.
 
+#### [Windows Installer Pipeline](examples/pipelines/windows-installer)
+
+Downloads a Windows Source ISO into a PVC and automatically installs Windows by using a custom Answer file into a new base PVC.
 
 ## Development Guide
 

--- a/examples/pipelines/server-deployer/README.md
+++ b/examples/pipelines/server-deployer/README.md
@@ -33,7 +33,6 @@ kubectl apply -f server-deployer-pipeline.yaml
 kubectl create -f server-deployer-pipelinerun.yaml
 ```
 
-
 ## Interact with the deployed app
 
 To expose and interact with the deployed application run the following snippet

--- a/examples/pipelines/unit-tester/README.md
+++ b/examples/pipelines/unit-tester/README.md
@@ -2,7 +2,6 @@
 
 Clones kubevirt-tekton-tasks repository and executes unit tests in a VM and then deletes the VM at the end.
 
-
 ## Prerequisites
 
 - KubeVirt `v0.36.0`
@@ -23,7 +22,6 @@ Clones kubevirt-tekton-tasks repository and executes unit tests in a VM and then
 4. `cleanup-vm` task attempts to connect to the VM.
     - prints unit tests results or `failure` if no test results found
     - deletes the VM
-
 
 ## How to run
 

--- a/examples/pipelines/windows-installer/README.md
+++ b/examples/pipelines/windows-installer/README.md
@@ -1,0 +1,85 @@
+# Windows Installer Pipeline
+
+Downloads a Windows Source ISO into a PVC and installs Windows into a new base PVC.
+It will then spin up an installation VM and use Windows Answer Files to automatically install the VM.
+Then the pipeline will wait for the installation to complete and will delete the installation VM while keeping the artifact PVC (backed by DataVolume) with the installed operating system.
+The pipeline can be customized to support different installation requirements.
+
+## Prerequisites
+
+- KubeVirt `v0.39.0`
+- Tekton Pipelines `v0.19.0`
+
+### Obtain Windows ISO download URL
+
+1. Go to https://www.microsoft.com/en-us/software-download/windows10ISO. You can also obtain a server edition for evaluation at https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019.
+2. Fill in the edition and `English` language (other languages need to be updated in windows-10-autounattend ConfigMap) and go to the download page.
+3. Right-click on the 64-bit download button and copy the download link. The link should be valid for 24 hours.
+4. Initialize a WIN_URL variable that will be used to create a DataVolume which will download this ISO into a PVC.
+
+```bash
+# Real URL can look differently
+WIN_URL="https://software-download.microsoft.com/db/Win10_20H2_v2_English_x64.iso..."
+```
+
+### Prepare autounattend.xml ConfigMap
+
+1. Supply, generate or use the default autounattend.xml.
+   The configuration file can be generated with [Windows SIM](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/wsim/windows-system-image-manager-overview-topics)
+   or it can be specified manually according to [Answer File Reference](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/wsim/answer-files-overview)
+   and [Answer File Components Reference](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/components-b-unattend).
+2. Replace the default example autounattend.xml with your own in `windows-installer-pipeline.yaml`.
+   You can also store the config inside a secret (VM definition requires changes in that case).
+   Different autounattend.xml can be also passed in the Pipeline parameters when creating a PipelineRun.
+
+## Pipeline Description
+
+```
+  create-source-dv --- create-vm-from-manifest --- wait-for-vmi-status --- cleanup-vm
+                    |
+    create-base-dv --
+```
+
+1. `create-source-dv` task downloads a Windows source ISO into a PVC called `windows-10-source-*`.
+2. `create-base-dv` task creates empty PVC for new windows installation called `windows-10-base-*`.
+3. `create-vm-from-manifest` task creates a VM called `windows-installer-*`
+   from the empty PVC and with `windows-10-source-*` PVC attached as a CD-ROM.
+4. ` wait-for-vmi-status` task waits until the VM shutdowns.
+5. `cleanup-vm` deletes the installer VM and ISO PVC.
+6.  The output artifact will be the `windows-10-base-*` PVC with the Windows installation. 
+    It includes an `Administrator` user with `changepassword` password.
+
+## How to run
+
+```bash
+WIN_URL="https://software-download.microsoft.com/db/Win10_20H2_v2_English_x64.iso..."
+kubectl apply -f windows-installer-pipeline.yaml
+sed 's!DOWNLOAD_URL!'"$WIN_URL"'!g' windows-installer-pipelinerun.yaml | kubectl create -f -
+```
+
+## Possible Optimizations
+
+### Windows Source ISO Caching
+
+Windows source ISO can be downloaded and cached/stored in a PVC.
+So the subsequent PipelineRuns don't have to download the same ISO multiple times.
+
+You can create the following DV first and remove create-source-dv step from the windows-installer-pipeline:
+
+```yaml
+ apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: windows-10-source
+spec:
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 7Gi
+    volumeMode: Filesystem
+  source:
+    http:
+      url: WIN_IMAGE_DOWNLOAD_URL
+```

--- a/examples/pipelines/windows-installer/windows-installer-pipeline.yaml
+++ b/examples/pipelines/windows-installer/windows-installer-pipeline.yaml
@@ -1,0 +1,352 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: windows-10-autounattend
+data:
+  Autounattend.xml: |
+    <?xml version="1.0" encoding="utf-8"?>
+    <unattend xmlns="urn:schemas-microsoft-com:unattend">
+        <settings pass="windowsPE">
+            <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="amd64" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+                <DriverPaths>
+                    <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                        <Path>E:\viostor\w10\amd64</Path>
+                    </PathAndCredentials>
+                    <PathAndCredentials wcm:action="add" wcm:keyValue="2">
+                        <Path>E:\NetKVM\w10\amd64</Path>
+                    </PathAndCredentials>
+                    <PathAndCredentials wcm:action="add" wcm:keyValue="3">
+                        <Path>E:\viorng\w10\amd64</Path>
+                    </PathAndCredentials>
+                </DriverPaths>
+            </component>
+            <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <SetupUILanguage>
+                    <UILanguage>en-US</UILanguage>
+                </SetupUILanguage>
+                <InputLocale>0409:00000409</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UILanguageFallback>en-US</UILanguageFallback>
+                <UserLocale>en-US</UserLocale>
+            </component>
+            <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <DiskConfiguration>
+                    <Disk wcm:action="add">
+                        <CreatePartitions>
+                            <CreatePartition wcm:action="add">
+                                <Order>1</Order>
+                                <Type>Primary</Type>
+                                <Size>100</Size>
+                            </CreatePartition>
+                            <CreatePartition wcm:action="add">
+                                <Extend>true</Extend>
+                                <Order>2</Order>
+                                <Type>Primary</Type>
+                            </CreatePartition>
+                        </CreatePartitions>
+                        <ModifyPartitions>
+                            <ModifyPartition wcm:action="add">
+                                <Active>true</Active>
+                                <Format>NTFS</Format>
+                                <Label>System Reserved</Label>
+                                <Order>1</Order>
+                                <PartitionID>1</PartitionID>
+                                <TypeID>0x27</TypeID>
+                            </ModifyPartition>
+                            <ModifyPartition wcm:action="add">
+                                <Active>true</Active>
+                                <Format>NTFS</Format>
+                                <Label>OS</Label>
+                                <Letter>C</Letter>
+                                <Order>2</Order>
+                                <PartitionID>2</PartitionID>
+                            </ModifyPartition>
+                        </ModifyPartitions>
+                        <DiskID>0</DiskID>
+                        <WillWipeDisk>true</WillWipeDisk>
+                    </Disk>
+                </DiskConfiguration>
+                <ImageInstall>
+                    <OSImage>
+                        <InstallTo>
+                            <DiskID>0</DiskID>
+                            <PartitionID>2</PartitionID>
+                        </InstallTo>
+                        <InstallToAvailablePartition>false</InstallToAvailablePartition>
+                    </OSImage>
+                </ImageInstall>
+                <UserData>
+                    <AcceptEula>true</AcceptEula>
+                    <FullName>Administrator</FullName>
+                    <Organization></Organization>
+                    <ProductKey>
+                        <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+                    </ProductKey>
+                </UserData>
+            </component>
+        </settings>
+        <settings pass="offlineServicing">
+            <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <EnableLUA>false</EnableLUA>
+            </component>
+        </settings>
+        <settings pass="generalize">
+            <component name="Microsoft-Windows-Security-SPP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <SkipRearm>1</SkipRearm>
+            </component>
+        </settings>
+        <settings pass="specialize">
+            <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <InputLocale>0409:00000409</InputLocale>
+                <SystemLocale>en-US</SystemLocale>
+                <UILanguage>en-US</UILanguage>
+                <UILanguageFallback>en-US</UILanguageFallback>
+                <UserLocale>en-US</UserLocale>
+            </component>
+            <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <SkipAutoActivation>true</SkipAutoActivation>
+            </component>
+            <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <CEIPEnabled>0</CEIPEnabled>
+            </component>
+            <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <ComputerName>WindowsVM</ComputerName>
+                <ProductKey>W269N-WFGWX-YVC9B-4J6C9-T83GX</ProductKey>
+            </component>
+        </settings>
+        <settings pass="oobeSystem">
+            <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <AutoLogon>
+                    <Password>
+                        <Value>changepassword</Value>
+                        <PlainText>true</PlainText>
+                    </Password>
+                    <Enabled>true</Enabled>
+                    <Username>Administrator</Username>
+                </AutoLogon>
+                <OOBE>
+                    <HideEULAPage>true</HideEULAPage>
+                    <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                    <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                    <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                    <NetworkLocation>Home</NetworkLocation>
+                    <SkipUserOOBE>true</SkipUserOOBE>
+                    <SkipMachineOOBE>true</SkipMachineOOBE>
+                    <ProtectYourPC>3</ProtectYourPC>
+                </OOBE>
+                <UserAccounts>
+                    <LocalAccounts>
+                        <LocalAccount wcm:action="add">
+                            <Password>
+                                <Value>changepassword</Value>
+                                <PlainText>true</PlainText>
+                            </Password>
+                            <Description></Description>
+                            <DisplayName>Administrator</DisplayName>
+                            <Group>Administrators</Group>
+                            <Name>Administrator</Name>
+                        </LocalAccount>
+                    </LocalAccounts>
+                </UserAccounts>
+                <RegisteredOrganization></RegisteredOrganization>
+                <RegisteredOwner>Administrator</RegisteredOwner>
+                <DisableAutoDaylightTimeSet>false</DisableAutoDaylightTimeSet>
+                <FirstLogonCommands>
+                    <SynchronousCommand wcm:action="add">
+                        <Description>Control Panel View</Description>
+                        <Order>1</Order>
+                        <CommandLine>reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel" /v StartupPage /t REG_DWORD /d 1 /f</CommandLine>
+                        <RequiresUserInput>true</RequiresUserInput>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <Order>2</Order>
+                        <Description>Control Panel Icon Size</Description>
+                        <RequiresUserInput>false</RequiresUserInput>
+                        <CommandLine>reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel" /v AllItemsIconView /t REG_DWORD /d 0 /f</CommandLine>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <Order>3</Order>
+                        <RequiresUserInput>false</RequiresUserInput>
+                        <CommandLine>cmd /C wmic useraccount where name="Administrator" set PasswordExpires=false</CommandLine>
+                        <Description>Password Never Expires</Description>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <Order>4</Order>
+                        <Description>Remove AutoAdminLogon</Description>
+                        <RequiresUserInput>false</RequiresUserInput>
+                        <CommandLine>reg add "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 0 /f</CommandLine>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <Order>5</Order>
+                        <RequiresUserInput>false</RequiresUserInput>
+                        <CommandLine>cmd /c shutdown /s /f /t 10</CommandLine>
+                        <Description>Shuts down the system</Description>
+                    </SynchronousCommand>
+                </FirstLogonCommands>
+                <TimeZone>Alaskan Standard Time</TimeZone>
+            </component>
+        </settings>
+    </unattend>
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: windows-installer
+spec:
+  params:
+    - name: winImageDownloadURL
+      type: string
+    - name: autounattendConfigMapName
+      default: windows-10-autounattend
+      type: string
+  tasks:
+    - name: create-source-dv
+      params:
+        - name: manifest
+          value: |
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            metadata:
+              generateName: windows-10-source-
+            spec:
+              pvc:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 7Gi
+                volumeMode: Filesystem
+              source:
+                http:
+                  url: $(params.winImageDownloadURL)
+        - name: waitForSuccess
+          value: 'true'
+      timeout: '2h'
+      taskRef:
+        kind: ClusterTask
+        name: create-datavolume-from-manifest
+    - name: create-base-dv
+      params:
+        - name: manifest
+          value: |
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataVolume
+            metadata:
+              generateName: windows-10-base-
+            spec:
+              pvc:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 20Gi
+                volumeMode: Filesystem
+              source:
+                blank: {}
+        - name: waitForSuccess
+          value: 'true'
+      taskRef:
+        kind: ClusterTask
+        name: create-datavolume-from-manifest
+    - name: create-vm-from-manifest
+      params:
+        - name: manifest
+          value: |
+            apiVersion: kubevirt.io/v1alpha3
+            kind: VirtualMachine
+            metadata:
+              generateName: windows-installer-
+              annotation:
+                description: Windows VM generated by windows-installer pipeline
+              labels:
+                app: windows-installer
+            spec:
+              runStrategy: RerunOnFailure
+              template:
+                metadata:
+                  labels:
+                    kubevirt.io/domain: windows-installer
+                spec:
+                  domain:
+                    cpu:
+                      sockets: 2
+                      cores: 1
+                      threads: 1
+                    resources:
+                      requests:
+                        memory: 2Gi
+                    devices:
+                      disks:
+                        - name: installcdrom
+                          cdrom:
+                            bus: sata
+                          bootOrder: 1
+                        - name: rootdisk
+                          bootOrder: 2
+                          disk:
+                            bus: virtio
+                        - name: virtiocontainerdisk
+                          cdrom:
+                            bus: sata
+                        - name: sysprepconfig
+                          cdrom:
+                            bus: sata
+                      interfaces:
+                        - bridge: {}
+                          name: default
+                      inputs:
+                        - type: tablet
+                          bus: usb
+                          name: tablet
+                  networks:
+                    - name: default
+                      pod: {}
+                  volumes:
+                    - name: installcdrom
+                    - name: rootdisk
+                    - name: virtiocontainerdisk
+                      containerDisk:
+                        image: kubevirt/virtio-container-disk
+                    - name: sysprepconfig
+                      sysprep:
+                        configMap:
+                          name: $(params.autounattendConfigMapName)
+        - name: ownDataVolumes
+          value:
+            - "installcdrom:$(tasks.create-source-dv.results.name)"
+        - name: dataVolumes
+          value:
+            - "rootdisk:$(tasks.create-base-dv.results.name)"
+      runAfter:
+        - create-source-dv
+        - create-base-dv
+      taskRef:
+        kind: ClusterTask
+        name: create-vm-from-manifest
+    - name: wait-for-vmi-status
+      params:
+        - name: vmiName
+          value: "$(tasks.create-vm-from-manifest.results.name)"
+        - name: successCondition
+          value: "status.phase == Succeeded"
+        - name: failureCondition
+          value: "status.phase in (Failed, Unknown)"
+      runAfter:
+        - create-vm-from-manifest
+      timeout: '2h'
+      taskRef:
+        kind: ClusterTask
+        name: wait-for-vmi-status
+    - name: cleanup-vm
+      params:
+        - name: vmName
+          value: "$(tasks.create-vm-from-manifest.results.name)"
+        - name: delete
+          value: "true"
+      runAfter:
+        - wait-for-vmi-status
+      taskRef:
+        kind: ClusterTask
+        name: cleanup-vm

--- a/examples/pipelines/windows-installer/windows-installer-pipelinerun.yaml
+++ b/examples/pipelines/windows-installer/windows-installer-pipelinerun.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows-installer-run-
+spec:
+  params:
+    - name: winImageDownloadURL
+      value: DOWNLOAD_URL
+  pipelineRef:
+    name: windows-installer
+  timeout: '5h'
+  serviceAccountNames:
+    - taskName: create-source-dv
+      serviceAccountName: create-datavolume-from-manifest-task
+    - taskName: create-base-dv
+      serviceAccountName: create-datavolume-from-manifest-task
+    - taskName: create-vm-from-manifest
+      serviceAccountName: create-vm-from-manifest-task
+    - taskName: wait-for-vmi-status
+      serviceAccountName: wait-for-vmi-status-task
+    - taskName: cleanup-vm
+      serviceAccountName: cleanup-vm-task

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -31,7 +31,7 @@ spec:
       name: delete
       type: string
       default: "false"
-    - description: Timeout for the command/script (includes potential VM start). The VM will be stoped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
+    - description: Timeout for the command/script (includes potential VM start). The VM will be stopped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
       name: timeout
       type: string
       default: "30m"
@@ -710,7 +710,7 @@ kind: ClusterTask
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task
-    vmNamespace.params.task.kubevirt.io/type: namespace
+    vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:
     task.kubevirt.io/type: wait-for-vmi-status
     task.kubevirt.io/category: wait-for-vmi-status

--- a/manifests/openshift/kubevirt-tekton-tasks-openshift.yaml
+++ b/manifests/openshift/kubevirt-tekton-tasks-openshift.yaml
@@ -31,7 +31,7 @@ spec:
       name: delete
       type: string
       default: "false"
-    - description: Timeout for the command/script (includes potential VM start). The VM will be stoped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
+    - description: Timeout for the command/script (includes potential VM start). The VM will be stopped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
       name: timeout
       type: string
       default: "30m"
@@ -864,7 +864,7 @@ kind: ClusterTask
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task
-    vmNamespace.params.task.kubevirt.io/type: namespace
+    vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:
     task.kubevirt.io/type: wait-for-vmi-status
     task.kubevirt.io/category: wait-for-vmi-status

--- a/tasks/cleanup-vm/README.md
+++ b/tasks/cleanup-vm/README.md
@@ -14,7 +14,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **vmNamespace**: Namespace of a VM to execute the action in. (defaults to active namespace)
 - **stop**: Stops the VM after executing the commands when set to true.
 - **delete**: Deletes the VM after executing the commands when set to true.
-- **timeout**: Timeout for the command/script (includes potential VM start). The VM will be stoped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
+- **timeout**: Timeout for the command/script (includes potential VM start). The VM will be stopped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
 - **secretName**: Secret to use when connecting to a VM.
 - **command**: Command to execute in a VM.
 - **args**: Arguments of a command.

--- a/tasks/cleanup-vm/manifests/cleanup-vm.yaml
+++ b/tasks/cleanup-vm/manifests/cleanup-vm.yaml
@@ -31,7 +31,7 @@ spec:
       name: delete
       type: string
       default: "false"
-    - description: Timeout for the command/script (includes potential VM start). The VM will be stoped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
+    - description: Timeout for the command/script (includes potential VM start). The VM will be stopped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
       name: timeout
       type: string
       default: "30m"

--- a/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -4,7 +4,7 @@ kind: ClusterTask
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task
-    vmNamespace.params.task.kubevirt.io/type: namespace
+    vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:
     task.kubevirt.io/type: wait-for-vmi-status
     task.kubevirt.io/category: wait-for-vmi-status

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -34,7 +34,7 @@ spec:
       name: delete
       type: string
       default: "false"
-    - description: Timeout for the command/script (includes potential VM start). The VM will be stoped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
+    - description: Timeout for the command/script (includes potential VM start). The VM will be stopped or deleted accordingly once the timout expires. Should be in a 3h2m1s format.
       name: timeout
       type: string
       default: "30m"

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -4,7 +4,7 @@ kind: ClusterTask
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}
-    vmNamespace.params.task.kubevirt.io/type: namespace
+    vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}


### PR DESCRIPTION
Downloads a Windows Source ISO into a PVC and installs Windows into a new root PVC.
It uses Windows Sysprep to automatically install the system. 
The pipeline can be customized to support different installation requirements. 

The artifact of this pipeline is a PVC (backed by DataVolume) with a custom Windows installation. 

[README](https://github.com/suomiy/kubevirt-tekton-tasks/tree/win-pipeline/examples/pipelines/windows-installer)

Todo:
- [x] implement wait-for-vm task (https://github.com/kubevirt/kubevirt-tekton-tasks/pull/81)