### PR TITLE
replaced kubevirt config map by patching kubevirt CR

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -29,17 +29,7 @@ kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBE
 
 kubectl create -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
 
-kubectl apply -f - <<EOF
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-data:
-  feature-gates: "DataVolumes"
----
-EOF
+kubectl patch kubevirt kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["DataVolumes"]}}}}'
 
 # Deploy Storage
 kubectl create -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"


### PR DESCRIPTION
kubevirt config map is deprecated and it is replaced by kubevirt CR.

Signed-off-by: Karel Šimon <ksimon@redhat.com>