### PR TITLE
Switch from golang builder image to ubi8

### DIFF
--- a/modules/copy-template/build/copy-template/Dockerfile
+++ b/modules/copy-template/build/copy-template/Dockerfile
@@ -1,2 +1,4 @@
-FROM golang:1.15 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/modules/create-vm/build/create-vm/Dockerfile
+++ b/modules/create-vm/build/create-vm/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=create-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on

--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS taskBuilder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS taskBuilder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=disk-virt-customize \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS taskBuilder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS taskBuilder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=disk-virt-sysprep \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on

--- a/modules/execute-in-vm/build/execute-in-vm/Dockerfile
+++ b/modules/execute-in-vm/build/execute-in-vm/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=execute-in-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on

--- a/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
+++ b/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=generate-ssh-keys \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on

--- a/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
+++ b/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
+RUN microdnf install -y golang-1.15.* && microdnf clean all
 ENV TASK_NAME=wait-for-vmi-status \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch from golang builder image to ubi8
this pr changes golang builder image to ubi8 minimal, due to
dockerhub rate limits.

**Special notes for your reviewer**:

**Release note**:
```
NONE

```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
