### PR TITLE
add startVM attribute for create-vm-from-template task

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -248,6 +248,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
+    startVM.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: create-vm-from-manifest
     task.kubevirt.io/category: create-vm
@@ -259,6 +260,10 @@ spec:
       type: string
     - name: namespace
       description: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
+      default: ""
+      type: string
+    - name: startVM
+      description: Start vm after creation.
       default: ""
       type: string
     - name: dataVolumes
@@ -302,6 +307,8 @@ spec:
           value: $(params.manifest)
         - name: VM_NAMESPACE
           value: $(params.namespace)
+        - name: START_VM
+          value: $(params.startVM)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -314,11 +321,18 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
       - virtualmachines
       - virtualmachineinstances
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
   - verbs:
       - '*'
     apiGroups:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -337,6 +337,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
+    startVM.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: create-vm-from-manifest
     task.kubevirt.io/category: create-vm
@@ -348,6 +349,10 @@ spec:
       type: string
     - name: namespace
       description: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
+      default: ""
+      type: string
+    - name: startVM
+      description: Start vm after creation.
       default: ""
       type: string
     - name: dataVolumes
@@ -391,6 +396,8 @@ spec:
           value: $(params.manifest)
         - name: VM_NAMESPACE
           value: $(params.namespace)
+        - name: START_VM
+          value: $(params.startVM)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -403,11 +410,18 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
       - virtualmachines
       - virtualmachineinstances
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
   - verbs:
       - '*'
     apiGroups:
@@ -465,6 +479,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
+    startVM.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: create-vm-from-template
     task.kubevirt.io/category: create-vm
@@ -549,6 +564,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
@@ -586,6 +602,12 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
 
 ---
 apiVersion: v1

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -486,6 +486,10 @@ spec:
       description: Namespace where to create the VM. (defaults to active namespace)
       default: ""
       type: string
+    - name: startVM
+      description: Start vm after creation.
+      default: ""
+      type: string
     - name: dataVolumes
       description: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. ["rootdisk:my-dv", "my-dv2"]
       default: []
@@ -531,6 +535,8 @@ spec:
           value: $(params.templateNamespace)
         - name: VM_NAMESPACE
           value: $(params.vmNamespace)
+        - name: START_VM
+          value: $(params.startVM)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/create-vm/cmd/create-vm/main.go
+++ b/modules/create-vm/cmd/create-vm/main.go
@@ -51,6 +51,13 @@ func main() {
 		exit.ExitFromError(OwnVolumesErrorExitCode, err)
 	}
 
+	if cliOptions.GetStartVMFlag() {
+		err := vmCreator.StartVM(vm.Namespace, vm.Name)
+		if err != nil {
+			exit.ExitFromError(StartVMErrorExitCode, err)
+		}
+	}
+
 	results := map[string]string{
 		NameResultName:      vm.Name,
 		NamespaceResultName: vm.Namespace,

--- a/modules/create-vm/pkg/constants/constants.go
+++ b/modules/create-vm/pkg/constants/constants.go
@@ -8,6 +8,7 @@ const (
 	CreateVMErrorExitCode     = 4
 	OwnVolumesErrorExitCode   = 5
 	WriteResultsExitCode      = 6
+	StartVMErrorExitCode      = 7
 )
 
 // Result names

--- a/modules/create-vm/pkg/utils/parse/clioptions.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions.go
@@ -53,10 +53,7 @@ func (c *CLIOptions) GetOwnDVNames() []string {
 }
 
 func (c *CLIOptions) GetStartVMFlag() bool {
-	if c.StartVM == "true" {
-		return true
-	}
-	return false
+	return c.StartVM == "true"
 }
 
 func (c *CLIOptions) GetPVCDiskNamesMap() map[string]string {

--- a/modules/create-vm/pkg/utils/parse/clioptions.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions.go
@@ -31,7 +31,7 @@ type CLIOptions struct {
 	OwnDataVolumes            []string          `arg:"--own-dvs" placeholder:"DV1 VOLUME_NAME:DV2 DV3" help:"Add DataVolumes to VM Volumes and add VM to DV ownerReferences. These DVs will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format."`
 	PersistentVolumeClaims    []string          `arg:"--pvcs" placeholder:"PVC1 VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
 	OwnPersistentVolumeClaims []string          `arg:"--own-pvcs" placeholder:"PVC1  VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes and add VM to PVC ownerReferences. These PVCs will be deleted once the created VM gets deleted. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
-	StartVM                   bool              `arg:"--start-vm,env:START_VM" help:"Start vm after creation. Only usable in template creation mode"`
+	StartVM                   string            `arg:"--start-vm,env:START_VM" help:"Start vm after creation"`
 	Output                    output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug                     bool              `arg:"--debug" help:"Sets DEBUG log level"`
 }
@@ -52,8 +52,11 @@ func (c *CLIOptions) GetOwnDVNames() []string {
 	return removeVolumePrefixes(c.OwnDataVolumes)
 }
 
-func (c *CLIOptions) GetStartVMFlag() *bool {
-	return &c.StartVM
+func (c *CLIOptions) GetStartVMFlag() bool {
+	if c.StartVM == "true" {
+		return true
+	}
+	return false
 }
 
 func (c *CLIOptions) GetPVCDiskNamesMap() map[string]string {

--- a/modules/create-vm/pkg/utils/parse/clioptions.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions.go
@@ -31,6 +31,7 @@ type CLIOptions struct {
 	OwnDataVolumes            []string          `arg:"--own-dvs" placeholder:"DV1 VOLUME_NAME:DV2 DV3" help:"Add DataVolumes to VM Volumes and add VM to DV ownerReferences. These DVs will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format."`
 	PersistentVolumeClaims    []string          `arg:"--pvcs" placeholder:"PVC1 VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
 	OwnPersistentVolumeClaims []string          `arg:"--own-pvcs" placeholder:"PVC1  VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes and add VM to PVC ownerReferences. These PVCs will be deleted once the created VM gets deleted. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
+	StartVM                   bool              `arg:"--start-vm,env:START_VM" help:"Start vm after creation. Only usable in template creation mode"`
 	Output                    output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug                     bool              `arg:"--debug" help:"Sets DEBUG log level"`
 }
@@ -49,6 +50,10 @@ func (c *CLIOptions) GetDVNames() []string {
 
 func (c *CLIOptions) GetOwnDVNames() []string {
 	return removeVolumePrefixes(c.OwnDataVolumes)
+}
+
+func (c *CLIOptions) GetStartVMFlag() *bool {
+	return &c.StartVM
 }
 
 func (c *CLIOptions) GetPVCDiskNamesMap() map[string]string {

--- a/modules/create-vm/pkg/utils/parse/clioptions_test.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions_test.go
@@ -16,6 +16,8 @@ import (
 var (
 	defaultNS      = "default"
 	testVMManifest = testobjects.NewTestVM().ToString()
+	trueVar        = true
+	falseVar       = false
 )
 
 var _ = Describe("CLIOptions", func() {
@@ -79,6 +81,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams":          map[string]string{},
 			"GetDebugLevel":              zapcore.InfoLevel,
 			"GetCreationMode":            constants.TemplateCreationMode,
+			"GetStartVMFlag":             &falseVar,
 		}),
 		table.Entry("handles template cli arguments", &parse.CLIOptions{
 			TemplateName:              "test",
@@ -91,6 +94,7 @@ var _ = Describe("CLIOptions", func() {
 			DataVolumes:               []string{"dv1", "mydisk2:dv2"},
 			OwnDataVolumes:            []string{"mydisk3:dv3", "dv4", "mydisk4:dv5"},
 			Debug:                     true,
+			StartVM:                   trueVar,
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       defaultNS,
 			"GetVirtualMachineNamespace": defaultNS,
@@ -117,6 +121,7 @@ var _ = Describe("CLIOptions", func() {
 			},
 			"GetDebugLevel":   zapcore.DebugLevel,
 			"GetCreationMode": constants.TemplateCreationMode,
+			"GetStartVMFlag":  &trueVar,
 		}),
 		table.Entry("handles vm cli arguments", &parse.CLIOptions{
 			VirtualMachineManifest:    testVMManifest,
@@ -127,6 +132,7 @@ var _ = Describe("CLIOptions", func() {
 			DataVolumes:               []string{"mydisk2:dv1", ":dv2"},
 			OwnDataVolumes:            []string{"dv3"},
 			Debug:                     true,
+			StartVM:                   falseVar,
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       "",
 			"GetVirtualMachineNamespace": defaultNS,
@@ -148,6 +154,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams": map[string]string{},
 			"GetDebugLevel":     zapcore.DebugLevel,
 			"GetCreationMode":   constants.VMManifestCreationMode,
+			"GetStartVMFlag":    &falseVar,
 		}),
 		table.Entry("handles trim", &parse.CLIOptions{
 			TemplateName:              "test",

--- a/modules/create-vm/pkg/utils/parse/clioptions_test.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions_test.go
@@ -81,7 +81,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams":          map[string]string{},
 			"GetDebugLevel":              zapcore.InfoLevel,
 			"GetCreationMode":            constants.TemplateCreationMode,
-			"GetStartVMFlag":             &falseVar,
+			"GetStartVMFlag":             falseVar,
 		}),
 		table.Entry("handles template cli arguments", &parse.CLIOptions{
 			TemplateName:              "test",
@@ -94,7 +94,7 @@ var _ = Describe("CLIOptions", func() {
 			DataVolumes:               []string{"dv1", "mydisk2:dv2"},
 			OwnDataVolumes:            []string{"mydisk3:dv3", "dv4", "mydisk4:dv5"},
 			Debug:                     true,
-			StartVM:                   trueVar,
+			StartVM:                   "true",
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       defaultNS,
 			"GetVirtualMachineNamespace": defaultNS,
@@ -121,7 +121,7 @@ var _ = Describe("CLIOptions", func() {
 			},
 			"GetDebugLevel":   zapcore.DebugLevel,
 			"GetCreationMode": constants.TemplateCreationMode,
-			"GetStartVMFlag":  &trueVar,
+			"GetStartVMFlag":  trueVar,
 		}),
 		table.Entry("handles vm cli arguments", &parse.CLIOptions{
 			VirtualMachineManifest:    testVMManifest,
@@ -132,7 +132,7 @@ var _ = Describe("CLIOptions", func() {
 			DataVolumes:               []string{"mydisk2:dv1", ":dv2"},
 			OwnDataVolumes:            []string{"dv3"},
 			Debug:                     true,
-			StartVM:                   falseVar,
+			StartVM:                   "false",
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       "",
 			"GetVirtualMachineNamespace": defaultNS,
@@ -154,7 +154,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams": map[string]string{},
 			"GetDebugLevel":     zapcore.DebugLevel,
 			"GetCreationMode":   constants.VMManifestCreationMode,
-			"GetStartVMFlag":    &falseVar,
+			"GetStartVMFlag":    falseVar,
 		}),
 		table.Entry("handles trim", &parse.CLIOptions{
 			TemplateName:              "test",

--- a/modules/create-vm/pkg/utils/parse/clioptions_test.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions_test.go
@@ -16,8 +16,6 @@ import (
 var (
 	defaultNS      = "default"
 	testVMManifest = testobjects.NewTestVM().ToString()
-	trueVar        = true
-	falseVar       = false
 )
 
 var _ = Describe("CLIOptions", func() {
@@ -81,7 +79,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams":          map[string]string{},
 			"GetDebugLevel":              zapcore.InfoLevel,
 			"GetCreationMode":            constants.TemplateCreationMode,
-			"GetStartVMFlag":             falseVar,
+			"GetStartVMFlag":             false,
 		}),
 		table.Entry("handles template cli arguments", &parse.CLIOptions{
 			TemplateName:              "test",
@@ -121,7 +119,7 @@ var _ = Describe("CLIOptions", func() {
 			},
 			"GetDebugLevel":   zapcore.DebugLevel,
 			"GetCreationMode": constants.TemplateCreationMode,
-			"GetStartVMFlag":  trueVar,
+			"GetStartVMFlag":  true,
 		}),
 		table.Entry("handles vm cli arguments", &parse.CLIOptions{
 			VirtualMachineManifest:    testVMManifest,
@@ -154,7 +152,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetTemplateParams": map[string]string{},
 			"GetDebugLevel":     zapcore.DebugLevel,
 			"GetCreationMode":   constants.VMManifestCreationMode,
-			"GetStartVMFlag":    falseVar,
+			"GetStartVMFlag":    false,
 		}),
 		table.Entry("handles trim", &parse.CLIOptions{
 			TemplateName:              "test",

--- a/modules/create-vm/pkg/vm/vm-provider.go
+++ b/modules/create-vm/pkg/vm/vm-provider.go
@@ -11,6 +11,7 @@ type virtualMachineProvider struct {
 
 type VirtualMachineProvider interface {
 	Create(namespace string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error)
+	Start(namespace, name string) error
 }
 
 func NewVirtualMachineProvider(client kubevirtcliv1.KubevirtClient) VirtualMachineProvider {
@@ -21,4 +22,8 @@ func NewVirtualMachineProvider(client kubevirtcliv1.KubevirtClient) VirtualMachi
 
 func (v *virtualMachineProvider) Create(namespace string, vm *kubevirtv1.VirtualMachine) (*kubevirtv1.VirtualMachine, error) {
 	return v.client.VirtualMachine(namespace).Create(vm)
+}
+
+func (v *virtualMachineProvider) Start(namespace, name string) error {
+	return v.client.VirtualMachine(namespace).Start(name)
 }

--- a/modules/create-vm/pkg/vmcreator/vm-creator.go
+++ b/modules/create-vm/pkg/vmcreator/vm-creator.go
@@ -124,6 +124,8 @@ func (v *VMCreator) createVMFromTemplate() (*kubevirtv1.VirtualMachine, error) {
 	}
 
 	vm.Namespace = v.targetNamespace
+	vm.Spec.Running = v.cliOptions.GetStartVMFlag()
+
 	virtualMachine.AddMetadata(vm, processedTemplate)
 	virtualMachine.AddVolumes(vm, templateValidations, v.cliOptions)
 

--- a/modules/create-vm/pkg/vmcreator/vm-creator.go
+++ b/modules/create-vm/pkg/vmcreator/vm-creator.go
@@ -70,6 +70,10 @@ func NewVMCreator(cliOptions *parse.CLIOptions) (*VMCreator, error) {
 	}, nil
 }
 
+func (v *VMCreator) StartVM(namespace, name string) error {
+	return v.virtualMachineProvider.Start(namespace, name)
+}
+
 func (v *VMCreator) CreateVM() (*kubevirtv1.VirtualMachine, error) {
 	switch v.cliOptions.GetCreationMode() {
 	case constants.TemplateCreationMode:
@@ -124,7 +128,6 @@ func (v *VMCreator) createVMFromTemplate() (*kubevirtv1.VirtualMachine, error) {
 	}
 
 	vm.Namespace = v.targetNamespace
-	vm.Spec.Running = v.cliOptions.GetStartVMFlag()
 
 	virtualMachine.AddMetadata(vm, processedTemplate)
 	virtualMachine.AddVolumes(vm, templateValidations, v.cliOptions)

--- a/modules/tests/test/constants/create-vm.go
+++ b/modules/tests/test/constants/create-vm.go
@@ -23,6 +23,7 @@ type createVMFromTemplateParams struct {
 	TemplateNamespace string
 	TemplateParams    string
 	VmNamespace       string
+	StartVM           string
 }
 
 var CreateVMParams = createVMParams{
@@ -42,6 +43,7 @@ var CreateVMFromTemplateParams = createVMFromTemplateParams{
 	TemplateNamespace: "templateNamespace",
 	TemplateParams:    "templateParams",
 	VmNamespace:       "vmNamespace",
+	StartVM:           "startVM",
 }
 
 type createVMResults struct {

--- a/modules/tests/test/create_vm_from_manifest_test.go
+++ b/modules/tests/test/create_vm_from_manifest_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
 var _ = Describe("Create VM from manifest", func() {
@@ -244,7 +245,7 @@ var _ = Describe("Create VM from manifest", func() {
 	})
 
 	Context("with StartVM", func() {
-		table.DescribeTable("VM is created successfully", func(config *testconfigs.CreateVMTestConfig, running bool) {
+		table.DescribeTable("VM is created successfully", func(config *testconfigs.CreateVMTestConfig, phase kubevirtv1.VirtualMachineInstancePhase, running bool) {
 			f.TestSetup(config)
 
 			expectedVMStub := config.TaskData.GetExpectedVMStubMeta()
@@ -260,7 +261,7 @@ var _ = Describe("Create VM from manifest", func() {
 				})
 
 			vm, err := vm.WaitForVM(f.KubevirtClient, f.CdiClient, expectedVMStub.Namespace, expectedVMStub.Name,
-				"", config.GetTaskRunTimeout(), false)
+				phase, config.GetTaskRunTimeout(), false)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*vm.Spec.Running).To(Equal(running), "vm should be in correct running phase")
@@ -278,7 +279,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "false",
 				},
-			}, false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
 			table.Entry("with invalid StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CreateVMFromManifestServiceAccountName,
@@ -292,7 +293,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "invalid_value",
 				},
-			}, false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
 			table.Entry("with true StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CreateVMFromManifestServiceAccountName,
@@ -306,7 +307,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "true",
 				},
-			}, true),
+			}, kubevirtv1.Running, true),
 		)
 	})
 })

--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume"
 	testtemplate "github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/template"
 	. "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
@@ -13,6 +14,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
 )
 
 var _ = Describe("Create VM from template", func() {
@@ -343,6 +345,7 @@ var _ = Describe("Create VM from template", func() {
 				DataVolumesToCreate: []*datavolume.TestDataVolume{
 					datavolume.NewBlankDataVolume("common-templates-src-dv"),
 				},
+				StartVM: "false",
 			},
 		}
 		f.TestSetup(config)
@@ -373,7 +376,7 @@ var _ = Describe("Create VM from template", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
-	It("VM is created from template properly ", func() {
+	It("VM is created from template properly and running", func() {
 		template := testtemplate.NewCirrosServerTinyTemplate().Build()
 		config := &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
@@ -385,6 +388,7 @@ var _ = Describe("Create VM from template", func() {
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-template-data")),
 				},
+				StartVM: "true",
 			},
 		}
 		f.TestSetup(config)
@@ -405,7 +409,7 @@ var _ = Describe("Create VM from template", func() {
 			})
 
 		vm, err := vm.WaitForVM(f.KubevirtClient, f.CdiClient, expectedVMStub.Namespace, expectedVMStub.Name,
-			"", config.GetTaskRunTimeout(), false)
+			kubevirtv1.Running, config.GetTaskRunTimeout(), false)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		vmName := expectedVMStub.Name

--- a/modules/tests/test/testconfigs/vm-test-config.go
+++ b/modules/tests/test/testconfigs/vm-test-config.go
@@ -1,6 +1,8 @@
 package testconfigs
 
 import (
+	"strings"
+
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume"
 	template2 "github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/template"
@@ -13,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	"sigs.k8s.io/yaml"
-	"strings"
 )
 
 type CreateVMTaskData struct {
@@ -30,6 +31,7 @@ type CreateVMTaskData struct {
 	IsCommonTemplate                         bool
 	UseDefaultTemplateNamespacesInTaskParams bool
 	UseDefaultVMNamespacesInTaskParams       bool
+	StartVM                                  string
 	ExpectedAdditionalDiskBus                string
 
 	// Params
@@ -371,6 +373,13 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 				Value: v1beta1.ArrayOrString{
 					Type:      v1beta1.ParamTypeString,
 					StringVal: vmNamespace,
+				},
+			},
+			v1beta1.Param{
+				Name: CreateVMFromTemplateParams.StartVM,
+				Value: v1beta1.ArrayOrString{
+					Type:      v1beta1.ParamTypeString,
+					StringVal: c.TaskData.StartVM,
 				},
 			},
 		)

--- a/modules/tests/test/testconfigs/vm-test-config.go
+++ b/modules/tests/test/testconfigs/vm-test-config.go
@@ -309,6 +309,13 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 				ArrayVal: c.TaskData.OwnPersistentVolumeClaims,
 			},
 		},
+		{
+			Name: CreateVMFromTemplateParams.StartVM,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: c.TaskData.StartVM,
+			},
+		},
 	}
 	var vmNamespace string
 	if !c.TaskData.UseDefaultVMNamespacesInTaskParams {
@@ -373,13 +380,6 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 				Value: v1beta1.ArrayOrString{
 					Type:      v1beta1.ParamTypeString,
 					StringVal: vmNamespace,
-				},
-			},
-			v1beta1.Param{
-				Name: CreateVMFromTemplateParams.StartVM,
-				Value: v1beta1.ArrayOrString{
-					Type:      v1beta1.ParamTypeString,
-					StringVal: c.TaskData.StartVM,
 				},
 			},
 		)

--- a/tasks/create-vm-from-manifest/README.md
+++ b/tasks/create-vm-from-manifest/README.md
@@ -11,6 +11,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 
 - **manifest**: YAML manifest of a VirtualMachine resource to be created.
 - **namespace**: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
+- **startVM**: Start vm after creation.
 - **dataVolumes**: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **ownDataVolumes**: Add DVs to VM Volumes and add VM to DV ownerReferences. These DataVolumes will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **persistentVolumeClaims**: Add PVCs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:PVC_NAME format. Eg. `["rootdisk:my-pvc", "my-pvc2"]`

--- a/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
@@ -16,6 +16,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
+    startVM.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: create-vm-from-manifest
     task.kubevirt.io/category: create-vm
@@ -27,6 +28,10 @@ spec:
       type: string
     - name: namespace
       description: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
+      default: ""
+      type: string
+    - name: startVM
+      description: Start vm after creation.
       default: ""
       type: string
     - name: dataVolumes
@@ -70,6 +75,8 @@ spec:
           value: $(params.manifest)
         - name: VM_NAMESPACE
           value: $(params.namespace)
+        - name: START_VM
+          value: $(params.startVM)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -82,11 +89,18 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
       - virtualmachines
       - virtualmachineinstances
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
   - verbs:
       - '*'
     apiGroups:

--- a/tasks/create-vm-from-template/README.md
+++ b/tasks/create-vm-from-template/README.md
@@ -15,6 +15,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **templateNamespace**: Namespace of an OKD template to create VM from. (defaults to active namespace)
 - **templateParams**: Template params to pass when processing the template manifest. Each param should have KEY:VAL format. Eg `["NAME:my-vm", "DESC:blue"]`
 - **vmNamespace**: Namespace where to create the VM. (defaults to active namespace)
+- **startVM**: Start vm after creation.
 - **dataVolumes**: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **ownDataVolumes**: Add DVs to VM Volumes and add VM to DV ownerReferences. These DataVolumes will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **persistentVolumeClaims**: Add PVCs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:PVC_NAME format. Eg. `["rootdisk:my-pvc", "my-pvc2"]`

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -18,6 +18,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
+    startVM.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: create-vm-from-template
     task.kubevirt.io/category: create-vm
@@ -102,6 +103,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
@@ -139,6 +141,12 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
 
 ---
 apiVersion: v1

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -39,6 +39,10 @@ spec:
       description: Namespace where to create the VM. (defaults to active namespace)
       default: ""
       type: string
+    - name: startVM
+      description: Start vm after creation.
+      default: ""
+      type: string
     - name: dataVolumes
       description: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. ["rootdisk:my-dv", "my-dv2"]
       default: []
@@ -84,6 +88,8 @@ spec:
           value: $(params.templateNamespace)
         - name: VM_NAMESPACE
           value: $(params.vmNamespace)
+        - name: START_VM
+          value: $(params.startVM)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/create-vm-from-manifest/manifests/create-vm-from-manifest-role.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm-from-manifest-role.yaml
@@ -9,11 +9,18 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
       - virtualmachines
       - virtualmachineinstances
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start
   - verbs:
       - '*'
     apiGroups:

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -25,6 +25,7 @@ metadata:
     persistentVolumeClaims.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
     ownPersistentVolumeClaims.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}
     ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
+    startVM.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}
@@ -55,11 +56,11 @@ spec:
       description: Namespace where to create the VM. (defaults to active namespace)
       default: ""
       type: string
+{% endif %}
     - name: startVM
       description: Start vm after creation.
       default: ""
       type: string
-{% endif %}
     - name: dataVolumes
       description: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. ["rootdisk:my-dv", "my-dv2"]
       default: []
@@ -106,8 +107,6 @@ spec:
           value: $(params.templateNamespace)
         - name: VM_NAMESPACE
           value: $(params.vmNamespace)
-        - name: START_VM
-          value: $(params.startVM)
 {% elif task_name == "create-vm-from-manifest" %}
       env:
         - name: VM_MANIFEST
@@ -115,3 +114,5 @@ spec:
         - name: VM_NAMESPACE
           value: $(params.namespace)
 {% endif %}
+        - name: START_VM
+          value: $(params.startVM)

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -55,6 +55,10 @@ spec:
       description: Namespace where to create the VM. (defaults to active namespace)
       default: ""
       type: string
+    - name: startVM
+      description: Start vm after creation.
+      default: ""
+      type: string
 {% endif %}
     - name: dataVolumes
       description: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. ["rootdisk:my-dv", "my-dv2"]
@@ -102,6 +106,8 @@ spec:
           value: $(params.templateNamespace)
         - name: VM_NAMESPACE
           value: $(params.vmNamespace)
+        - name: START_VM
+          value: $(params.startVM)
 {% elif task_name == "create-vm-from-manifest" %}
       env:
         - name: VM_MANIFEST

--- a/templates/create-vm-from-template/manifests/create-vm-from-template-role.yaml
+++ b/templates/create-vm-from-template/manifests/create-vm-from-template-role.yaml
@@ -9,6 +9,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - kubevirt.io
     resources:
@@ -46,3 +47,9 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - 'update'
+    apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/start


### PR DESCRIPTION
**What this PR does / why we need it**:
add startVM attribute for create-vm-from-template task
This attribute starts vm after creation

**Special notes for your reviewer**:

**Release note**:
```
add startVM attribute for create-vm-from-template task
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
