### PR TITLE
pin ginkgo and gomega to 1.15 version

### DIFF
--- a/automation/build-test.sh
+++ b/automation/build-test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
+export GO111MODULE=on
 go get github.com/jstemmer/go-junit-report
 
-go get github.com/onsi/ginkgo/ginkgo
-go get github.com/onsi/gomega/...
-go get github.com/onsi/ginkgo/extensions/table
+go get github.com/onsi/ginkgo/ginkgo@v1.15.2
+go get github.com/onsi/gomega/...@v1.15.0
+go get github.com/onsi/ginkgo/extensions/table@v1.15.2


### PR DESCRIPTION
**What this PR does / why we need it**:
pin ginkgo and gomega to 1.15 version
1.16 versions are currently not working with our tests.

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
