### PR TITLE
add release automation and offense language validation via github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+on:
+  release:
+    types: [published]
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+
+      - name: Publish tekton images and generate release manifests
+        run: |
+          echo ${{ secrets.QUAY_PASSWORD }} | podman login -u="${{ secrets.QUAY_BOT }}" --password-stdin quay.io
+          export IMG_TAG="${{ steps.get_release.outputs.tag_name }}"
+          make release
+
+      - name: Upload kubernetes manifest
+        id: kubernetes-manifest 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+          asset_name: kubevirt-tekton-tasks-kubernetes.yaml
+          asset_content_type: text/plain
+
+      - name: Upload okd manifest
+        id: okd-manifest  
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: manifests/okd/kubevirt-tekton-tasks-okd.yaml
+          asset_name: kubevirt-tekton-tasks-okd.yaml
+          asset_content_type: text/plain

--- a/.github/workflows/validate-no-offensive-lang.yml
+++ b/.github/workflows/validate-no-offensive-lang.yml
@@ -1,0 +1,15 @@
+name: validate-no-offensive-lang
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: validate-no-offensive-lang
+      run: scripts/validate-no-offensive-lang.sh

--- a/makefile
+++ b/makefile
@@ -45,6 +45,14 @@ e2e-tests:
 onboard-new-task-with-ci-stub:
 	./scripts/onboard-new-task-with-ci-stub.sh
 
+build-release-images:
+	./scripts/build-release-images.sh
+
+push-release-images:
+	./scripts/push-release-images.sh
+
+release: generate-yaml-tasks build-release-images push-release-images
+
 vendor:
 	./scripts/vendor.sh
 
@@ -63,6 +71,7 @@ vendor:
 	cluster-test \
 	cluster-clean \
 	cluster-clean-and-skip-images \
+	release \
 	e2e-tests \
 	onboard-new-task-with-ci-stub \
 	vendor

--- a/scripts/build-release-images.sh
+++ b/scripts/build-release-images.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${IMG_TAG}" ]; then
+  echo "IMG_TAG is not defined"
+  exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_DIR="$(realpath "${SCRIPT_DIR}/..")"
+
+source "${SCRIPT_DIR}/release-var.sh"
+source "${SCRIPT_DIR}/common.sh"
+
+
+visit "${REPO_DIR}"
+  visit modules
+    for TASK_NAME in *; do
+      if echo "${TASK_NAME}" | grep -vqE "^(${EXCLUDED_NON_IMAGE_MODULES})$"; then
+        if [ ! -d  "${TASK_NAME}" ]; then
+          continue
+        fi
+        visit "${TASK_NAME}"
+          IMAGE_NAME_AND_TAG="tekton-task-${TASK_NAME}:${IMG_TAG}"
+          IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
+          podman build -f "build/${TASK_NAME}/Dockerfile" -t "${IMAGE}" .
+        leave
+      fi
+    done
+  leave
+leave

--- a/scripts/push-release-images.sh
+++ b/scripts/push-release-images.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "${IMG_TAG}" ]; then
+  echo "IMG_TAG is not defined"
+  exit 1
+fi
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_DIR="$(realpath "${SCRIPT_DIR}/..")"
+
+source "${SCRIPT_DIR}/release-var.sh"
+source "${SCRIPT_DIR}/common.sh"
+
+visit "${REPO_DIR}"
+  visit modules
+    for TASK_NAME in *; do
+        if echo "${TASK_NAME}" | grep -vqE "^(${EXCLUDED_NON_IMAGE_MODULES})$"; then
+            if [ ! -d  "${TASK_NAME}" ]; then
+                continue
+            fi
+            visit "${TASK_NAME}"
+                IMAGE_NAME_AND_TAG="tekton-task-${TASK_NAME}:${IMG_TAG}"
+                export IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
+
+                echo "Pushing ${IMAGE}"
+                
+                podman push "${IMAGE}"
+            leave
+        fi
+    done
+  leave
+leave
+

--- a/scripts/release-var.sh
+++ b/scripts/release-var.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export REGISTRY="quay.io"
+export REPOSITORY="kubevirt"

--- a/scripts/validate-no-offensive-lang.sh
+++ b/scripts/validate-no-offensive-lang.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+OFFENSIVE_WORDS="black[ -]?list|white[ -]?list|master|slave"
+ALLOW_LIST=".+[:/=]master[a-zA-Z]*/?"
+MODULES_VENDOR=(':!modules/tests/vendor' ':!modules/sharedtest/vendor' ':!modules/shared/vendor' ':!modules/modify-vm-template/vendor' ':!modules/generate-ssh-keys/vendor' ':!modules/execute-in-vm/vendor' ':!modules/disk-virt-sysprep/vendor' ':!modules/disk-virt-customize/vendor' ':!modules/create-vm/vendor' ':!modules/copy-template/vendor' ':!modules/wait-for-vmi-status/vendor')
+MODULES_GOMOD=(':!modules/tests/go.mod' ':!modules/sharedtest/go.mod' ':!modules/shared/go.mod' ':!modules/modify-vm-template/go.mod' ':!modules/generate-ssh-keys/go.mod' ':!modules/execute-in-vm/go.mod' ':!modules/disk-virt-sysprep/go.mod' ':!modules/disk-virt-customize/go.mod' ':!modules/create-vm/go.mod' ':!modules/copy-template/go.mod' ':!modules/wait-for-vmi-status/go.mod')
+
+if git grep -inE "${OFFENSIVE_WORDS}" -- "${MODULES_VENDOR[@]}" "${MODULES_GOMOD[@]}" ":!${BASH_SOURCE[0]}" ':!.github/workflows/' | grep -viE "${ALLOW_LIST}"; then
+  echo "Validation failed. Found offensive language"
+  exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
add release automation and offense language validation via github actions

This PR adds release automation, which creates new images and deploy
manifests when new github release is done.
Add script which checks offense language and if any is found, fail test.

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
