### PR TITLE
update centos repos URL

### DIFF
--- a/modules/disk-virt-customize/build/disk-virt-customize/repos/CentOS-Stream-rhsrvany.repo
+++ b/modules/disk-virt-customize/build/disk-virt-customize/repos/CentOS-Stream-rhsrvany.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 8 - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [appstream]
 name=CentOS Stream 8 - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -16,7 +16,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [powertools]
 name=CentOS Stream 8 - PowerTools
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=PowerTools&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1

--- a/modules/disk-virt-customize/build/disk-virt-customize/repos/CentOS-Stream.repo
+++ b/modules/disk-virt-customize/build/disk-virt-customize/repos/CentOS-Stream.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 8 - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [appstream]
 name=CentOS Stream 8 - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/repos/CentOS-Stream-rhsrvany.repo
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/repos/CentOS-Stream-rhsrvany.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 8 - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [appstream]
 name=CentOS Stream 8 - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -16,7 +16,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [powertools]
 name=CentOS Stream 8 - PowerTools
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=PowerTools&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/repos/CentOS-Stream.repo
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/repos/CentOS-Stream.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 8 - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 [appstream]
 name=CentOS Stream 8 - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos-8/8/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1


### PR DESCRIPTION
**What this PR does / why we need it**:
update centos repos URL
Centos 8 is EOL, update URLs to centos stream 8

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
