### PR TITLE
update golang version in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.2.2


### PR DESCRIPTION
**What this PR does / why we need it**:
update golang version in github actions

github actions will now use golang 1.17

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
