### PR TITLE
Add deleteDatavolumeTemplate parameter to modify-vm-template task

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -988,6 +988,7 @@ metadata:
     cpuCores.params.task.kubevirt.io/type: number
     cpuThreads.params.task.kubevirt.io/type: number
     memory.params.task.kubevirt.io/type: memory
+    deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -1036,6 +1037,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - name: deleteDatavolumeTemplate
+      description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -1074,6 +1079,8 @@ spec:
           value: $(params.cpuThreads)
         - name: MEMORY
           value: $(params.memory)
+        - name: DELETE_DATAVOLUME_TEMPLATE
+          value: $(params.deleteDatavolumeTemplate)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/modify-vm-template/pkg/utils/parse/clioptions.go
+++ b/modules/modify-vm-template/pkg/utils/parse/clioptions.go
@@ -21,20 +21,21 @@ const (
 )
 
 type CLIOptions struct {
-	TemplateName        string            `arg:"--template-name,env:TEMPLATE_NAME,required" placeholder:"NAME" help:"Name of a template"`
-	TemplateNamespace   string            `arg:"--template-namespace,env:TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a template"`
-	CPUSockets          string            `arg:"--cpu-sockets,env:CPU_SOCKETS" placeholder:"CPU_SOCKETS" help:"Number of CPU sockets"`
-	CPUCores            string            `arg:"--cpu-cores,env:CPU_CORES" placeholder:"CPU_CORES" help:"Number of CPU cores"`
-	CPUThreads          string            `arg:"--cpu-threads,env:CPU_THREADS" placeholder:"CPU_THREADS" help:"Number of CPU threads"`
-	Memory              string            `arg:"--memory,env:MEMORY" placeholder:"MEMORY" help:"Memory of the vm, format 1M, 1G"`
-	TemplateLabels      []string          `arg:"--template-labels" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds labels to template"`
-	TemplateAnnotations []string          `arg:"--template-annotations" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds annotations to template"`
-	VMLabels            []string          `arg:"--vm-labels" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds labels to VMs"`
-	VMAnnotations       []string          `arg:"--vm-annotations" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds annotations to VMs"`
-	Output              output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
-	Disks               []string          `arg:"--disks" placeholder:'{"name": "test", "cdrom": {"bus": "sata"}}' '{"name": "disk2"}' help:"VM disks in json format, replace vm disk if same name, otherwise new disk is appended"`
-	Volumes             []string          `arg:"--volumes" placeholder:'{"name": "virtiocontainerdisk", "containerDisk": {"image": "kubevirt/virtio-container-disk"}}' '{"name": "disk2"}' help:"VM volumes in json format, replace vm volume if same name, otherwise new volume is appended"`
-	Debug               bool              `arg:"--debug" help:"Sets DEBUG log level"`
+	TemplateName             string            `arg:"--template-name,env:TEMPLATE_NAME,required" placeholder:"NAME" help:"Name of a template"`
+	TemplateNamespace        string            `arg:"--template-namespace,env:TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a template"`
+	CPUSockets               string            `arg:"--cpu-sockets,env:CPU_SOCKETS" placeholder:"CPU_SOCKETS" help:"Number of CPU sockets"`
+	CPUCores                 string            `arg:"--cpu-cores,env:CPU_CORES" placeholder:"CPU_CORES" help:"Number of CPU cores"`
+	CPUThreads               string            `arg:"--cpu-threads,env:CPU_THREADS" placeholder:"CPU_THREADS" help:"Number of CPU threads"`
+	Memory                   string            `arg:"--memory,env:MEMORY" placeholder:"MEMORY" help:"Memory of the vm, format 1M, 1G"`
+	TemplateLabels           []string          `arg:"--template-labels" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds labels to template"`
+	TemplateAnnotations      []string          `arg:"--template-annotations" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds annotations to template"`
+	VMLabels                 []string          `arg:"--vm-labels" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds labels to VMs"`
+	VMAnnotations            []string          `arg:"--vm-annotations" placeholder:"KEY: VALUE KEY: VALUE" help:"Adds annotations to VMs"`
+	Output                   output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
+	Disks                    []string          `arg:"--disks" placeholder:'{"name": "test", "cdrom": {"bus": "sata"}}' '{"name": "disk2"}' help:"VM disks in json format, replace vm disk if same name, otherwise new disk is appended"`
+	Volumes                  []string          `arg:"--volumes" placeholder:'{"name": "virtiocontainerdisk", "containerDisk": {"image": "kubevirt/virtio-container-disk"}}' '{"name": "disk2"}' help:"VM volumes in json format, replace vm volume if same name, otherwise new volume is appended"`
+	DeleteDatavolumeTemplate bool              `arg:"--delete-datavolume-template,env:DELETE_DATAVOLUME_TEMPLATE" help:"Delete datavolume template from template. It deletes associated volumes and disks from VM definition"`
+	Debug                    bool              `arg:"--debug" help:"Sets DEBUG log level"`
 
 	templateLabels      map[string]string
 	templateAnnotations map[string]string
@@ -59,6 +60,10 @@ func (c *CLIOptions) GetCPUSockets() uint32 {
 func (c *CLIOptions) GetCPUCores() uint32 {
 	res, _ := strconv.ParseUint(c.CPUCores, 10, 32)
 	return uint32(res)
+}
+
+func (c *CLIOptions) GetDeleteDatavolumeTemplate() bool {
+	return c.DeleteDatavolumeTemplate
 }
 
 func (c *CLIOptions) GetCPUThreads() uint32 {

--- a/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
+++ b/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
@@ -68,15 +68,16 @@ var _ = Describe("CLIOptions", func() {
 				Debug:        true,
 			}),
 			table.Entry("should succeed with all options", &parse.CLIOptions{
-				TemplateName:        testString,
-				CPUCores:            testNumberOfCPU,
-				CPUThreads:          testNumberOfCPU,
-				TemplateLabels:      mockArray,
-				TemplateAnnotations: mockArray,
-				VMLabels:            mockArray,
-				VMAnnotations:       mockArray,
-				Disks:               diskArray,
-				Volumes:             volumeArray,
+				TemplateName:             testString,
+				CPUCores:                 testNumberOfCPU,
+				CPUThreads:               testNumberOfCPU,
+				TemplateLabels:           mockArray,
+				TemplateAnnotations:      mockArray,
+				VMLabels:                 mockArray,
+				VMAnnotations:            mockArray,
+				Disks:                    diskArray,
+				Volumes:                  volumeArray,
+				DeleteDatavolumeTemplate: true,
 			}),
 		)
 
@@ -119,13 +120,14 @@ var _ = Describe("CLIOptions", func() {
 		)
 
 		cli := &parse.CLIOptions{
-			TemplateName:        testString,
-			TemplateLabels:      mockArray,
-			TemplateAnnotations: mockArray,
-			VMLabels:            mockArray,
-			VMAnnotations:       mockArray,
-			Disks:               diskArray,
-			Volumes:             volumeArray,
+			TemplateName:             testString,
+			TemplateLabels:           mockArray,
+			TemplateAnnotations:      mockArray,
+			VMLabels:                 mockArray,
+			VMAnnotations:            mockArray,
+			Disks:                    diskArray,
+			Volumes:                  volumeArray,
+			DeleteDatavolumeTemplate: true,
 		}
 		table.DescribeTable("CLI options should return correct map of annotations / labels", func(obj *parse.CLIOptions, fnToCall func() map[string]string, result map[string]string) {
 			Expect(obj.Init()).To(Succeed(), "should succeeded")
@@ -153,6 +155,13 @@ var _ = Describe("CLIOptions", func() {
 			Expect(r[0].ContainerDisk.Image).To(Equal(result[0].ContainerDisk.Image), "volume image should equal")
 		},
 			table.Entry("GetVolumes should return correct value", cli, cli.GetVolumes, parsedVolume),
+		)
+
+		table.DescribeTable("CLI options should return correct value for DeleteDatavolumeTemplate", func(obj *parse.CLIOptions, fnToCall func() bool, result bool) {
+			Expect(obj.Init()).To(Succeed(), "should succeeded")
+			Expect(fnToCall()).To(Equal(result), "bool should equal")
+		},
+			table.Entry("GetDeleteDatavolumeTemplate should return correct value", cli, cli.GetDeleteDatavolumeTemplate, true),
 		)
 	})
 })

--- a/modules/sharedtest/testobjects/template/rhel-tiny.go
+++ b/modules/sharedtest/testobjects/template/rhel-tiny.go
@@ -1,0 +1,172 @@
+package template
+
+import (
+	v1 "github.com/openshift/api/template/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	RhelTemplateName = "rhel8-desktop-tiny"
+)
+const rhelDesktopTinyTemplateYAML = `
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      registry.redhat.io/rhel8/rhel-guest-image
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.19.3"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.19.3"
+      vm.kubevirt.io/template.revision: "20"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
+  value: 'rhel8'
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+
+`
+
+func NewRhelDesktopTinyTemplate() *TestTemplate {
+	var template v1.Template
+	err := yaml.Unmarshal([]byte(rhelDesktopTinyTemplateYAML), &template)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &TestTemplate{
+		&template,
+	}
+}

--- a/modules/tests/test/constants/modify-vm-template.go
+++ b/modules/tests/test/constants/modify-vm-template.go
@@ -21,6 +21,7 @@ const (
 	VMAnnotationsOptionName       = "vmAnnotations"
 	DisksOptionName               = "disks"
 	VolumesOptionName             = "volumes"
+	DeleteDatavolumeTemplateName  = "deleteDatavolumeTemplate"
 
 	CPUSocketsTopologyNumber    uint32 = 1
 	CPUCoresTopologyNumber      uint32 = 2

--- a/modules/tests/test/testconfigs/modify-vm-template-test-config.go
+++ b/modules/tests/test/testconfigs/modify-vm-template-test-config.go
@@ -1,6 +1,8 @@
 package testconfigs
 
 import (
+	"strconv"
+
 	. "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/framework/testoptions"
 	v1 "github.com/openshift/api/template/v1"
@@ -11,19 +13,20 @@ import (
 type ModifyTemplateTaskData struct {
 	Template *v1.Template
 
-	TemplateName            string
-	SourceTemplateNamespace TargetNamespace
-	CPUCores                string
-	CPUSockets              string
-	CPUThreads              string
-	Memory                  string
-	TemplateNamespace       string
-	TemplateLabels          []string
-	TemplateAnnotations     []string
-	VMAnnotations           []string
-	VMLabels                []string
-	Disks                   []string
-	Volumes                 []string
+	TemplateName             string
+	SourceTemplateNamespace  TargetNamespace
+	CPUCores                 string
+	CPUSockets               string
+	CPUThreads               string
+	Memory                   string
+	TemplateNamespace        string
+	TemplateLabels           []string
+	TemplateAnnotations      []string
+	VMAnnotations            []string
+	VMLabels                 []string
+	Disks                    []string
+	Volumes                  []string
+	DeleteDatavolumeTemplate bool
 }
 
 type ModifyTemplateTestConfig struct {
@@ -119,6 +122,12 @@ func (m *ModifyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			Value: v1beta1.ArrayOrString{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: m.TaskData.Volumes,
+			},
+		}, {
+			Name: DeleteDatavolumeTemplateName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: strconv.FormatBool(m.TaskData.DeleteDatavolumeTemplate),
 			},
 		},
 	}

--- a/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/template/rhel-tiny.go
+++ b/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/template/rhel-tiny.go
@@ -1,0 +1,172 @@
+package template
+
+import (
+	v1 "github.com/openshift/api/template/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	RhelTemplateName = "rhel8-desktop-tiny"
+)
+const rhelDesktopTinyTemplateYAML = `
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhel8-desktop-tiny
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8.0+ VM"
+    description: >-
+      Template for Red Hat Enterprise Linux 8 VM or newer.
+      A PVC with the RHEL disk image must be available.
+    tags: "hidden,kubevirt,virtualmachine,linux,rhel"
+    iconClass: "icon-rhel"
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-templates"
+    openshift.io/support-url: "https://github.com/kubevirt/common-templates/issues"
+    template.openshift.io/bindable: "false"
+    template.kubevirt.io/version: v1alpha1
+    defaults.template.kubevirt.io/disk: rootdisk
+    template.kubevirt.io/containerdisks: |
+      registry.redhat.io/rhel8/rhel-guest-image
+    template.kubevirt.io/editable: |
+      /objects[0].spec.template.spec.domain.cpu.sockets
+      /objects[0].spec.template.spec.domain.cpu.cores
+      /objects[0].spec.template.spec.domain.cpu.threads
+      /objects[0].spec.template.spec.domain.resources.requests.memory
+      /objects[0].spec.template.spec.domain.devices.disks
+      /objects[0].spec.template.spec.volumes
+      /objects[0].spec.template.spec.networks
+    name.os.template.kubevirt.io/rhel8.0: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.1: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.2: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.3: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.4: Red Hat Enterprise Linux 8.0 or higher
+    name.os.template.kubevirt.io/rhel8.5: Red Hat Enterprise Linux 8.0 or higher
+  labels:
+    os.template.kubevirt.io/rhel8.0: "true"
+    os.template.kubevirt.io/rhel8.1: "true"
+    os.template.kubevirt.io/rhel8.2: "true"
+    os.template.kubevirt.io/rhel8.3: "true"
+    os.template.kubevirt.io/rhel8.4: "true"
+    os.template.kubevirt.io/rhel8.5: "true"
+    workload.template.kubevirt.io/desktop: "true"
+    flavor.template.kubevirt.io/tiny: "true"
+    template.kubevirt.io/type: "base"
+    template.kubevirt.io/version: "v0.19.3"
+objects:
+- apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    name: ${NAME}
+    labels:
+      vm.kubevirt.io/template: rhel8-desktop-tiny
+      vm.kubevirt.io/template.version: "v0.19.3"
+      vm.kubevirt.io/template.revision: "20"
+      app: ${NAME}
+    annotations:
+      vm.kubevirt.io/validations: |
+        [
+          {
+            "name": "minimal-required-memory",
+            "path": "jsonpath::.spec.domain.resources.requests.memory",
+            "rule": "integer",
+            "message": "This VM requires more memory.",
+            "min": 1610612736
+          }
+        ]
+  spec:
+    dataVolumeTemplates:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: ${NAME}
+      spec:
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+        sourceRef:
+          kind: DataSource
+          name: ${DATA_SOURCE_NAME}
+          namespace: ${DATA_SOURCE_NAMESPACE}
+    running: false
+    template:
+      metadata:
+        annotations:
+          vm.kubevirt.io/os: "rhel8"
+          vm.kubevirt.io/workload: "desktop"
+          vm.kubevirt.io/flavor: "tiny"
+        labels:
+          kubevirt.io/domain: ${NAME}
+          kubevirt.io/size: tiny
+      spec:
+        domain:
+          cpu:
+            sockets: 1
+            cores: 1
+            threads: 1
+          resources:
+            requests:
+              memory: 1.5Gi
+          devices:
+            rng: {}
+            networkInterfaceMultiqueue: true
+            inputs:
+              - type: tablet
+                bus: virtio
+                name: tablet
+            disks:
+            - disk:
+                bus: virtio
+              name: rootdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
+        terminationGracePeriodSeconds: 180
+        networks:
+        - name: default
+          pod: {}
+        volumes:
+        - dataVolume:
+            name: ${NAME}
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |-
+              #cloud-config
+              user: cloud-user
+              password: ${CLOUD_USER_PASSWORD}
+              chpasswd: { expire: False }
+          name: cloudinitdisk
+parameters:
+- description: VM name
+  from: 'rhel8-[a-z0-9]{16}'
+  generate: expression
+  name: NAME
+- name: DATA_SOURCE_NAME
+  description: Name of the DataSource to clone
+  value: 'rhel8'
+- name: DATA_SOURCE_NAMESPACE
+  description: Namespace of the DataSource
+  value: kubevirt-os-images
+- description: Randomized password for the cloud-init user cloud-user
+  from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
+  generate: expression
+  name: CLOUD_USER_PASSWORD
+
+`
+
+func NewRhelDesktopTinyTemplate() *TestTemplate {
+	var template v1.Template
+	err := yaml.Unmarshal([]byte(rhelDesktopTinyTemplateYAML), &template)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &TestTemplate{
+		&template,
+	}
+}

--- a/tasks/modify-vm-template/README.md
+++ b/tasks/modify-vm-template/README.md
@@ -22,6 +22,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **vmAnnotations**: VM annotations. If VM contains same annotation, it will be replaced. Each param should have KEY:VAL format. Eg [`key:value`, `key:value`].
 - **disks**: VM disks in json format, replace vm disk if same name, otherwise new disk is appended. Eg [{`name`: `test`, `cdrom`: {`bus`: `sata`}}, {`name`: `disk2`}]
 - **volumes**: VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{`name`: `virtiocontainerdisk`, `containerDisk`: {`image`: `kubevirt/virtio-container-disk`}}]
+- **deleteDatavolumeTemplate**: Set to `true` or `false` if task should delete datavolume template in template and all associated volumes and disks.
 
 ### Results
 

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -11,6 +11,7 @@ metadata:
     cpuCores.params.task.kubevirt.io/type: number
     cpuThreads.params.task.kubevirt.io/type: number
     memory.params.task.kubevirt.io/type: memory
+    deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -59,6 +60,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - name: deleteDatavolumeTemplate
+      description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -97,6 +102,8 @@ spec:
           value: $(params.cpuThreads)
         - name: MEMORY
           value: $(params.memory)
+        - name: DELETE_DATAVOLUME_TEMPLATE
+          value: $(params.deleteDatavolumeTemplate)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -11,6 +11,7 @@ metadata:
     cpuCores.params.task.kubevirt.io/type: {{ task_param_types.number }}
     cpuThreads.params.task.kubevirt.io/type: {{ task_param_types.number }}
     memory.params.task.kubevirt.io/type: {{ task_param_types.memory }}
+    deleteDatavolumeTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}
@@ -59,6 +60,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - name: deleteDatavolumeTemplate
+      description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -97,3 +102,5 @@ spec:
           value: $(params.cpuThreads)
         - name: MEMORY
           value: $(params.memory)
+        - name: DELETE_DATAVOLUME_TEMPLATE
+          value: $(params.deleteDatavolumeTemplate)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add deleteDatavolumeTemplate parameter to modify-vm-template task
this parameter removes datavolume template from template and removes
all associated volumes and disks.

**Release note**:
```
Add deleteDatavolumeTemplate parameter to modify-vm-template task
```
