### PR TITLE
bump quay.io/kubevirt/libguestfs-tools image to v0.52.0

### DIFF
--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone https://github.com/rwmjones/rhsrvany.git
 WORKDIR /rhsrvany
 RUN autoreconf --install && autoconf && mingw32-configure --disable-dependency-tracking && make
 
-FROM quay.io/kubevirt/libguestfs-tools:v0.49.0
+FROM quay.io/kubevirt/libguestfs-tools:v0.52.0
 ENV TASK_NAME=disk-virt-customize
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_UID=1001 \

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone https://github.com/rwmjones/rhsrvany.git
 WORKDIR /rhsrvany
 RUN autoreconf --install && autoconf && mingw32-configure --disable-dependency-tracking && make
 
-FROM quay.io/kubevirt/libguestfs-tools:v0.49.0
+FROM quay.io/kubevirt/libguestfs-tools:v0.52.0
 ENV TASK_NAME=disk-virt-sysprep
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_UID=1001 \


### PR DESCRIPTION
**What this PR does / why we need it**:
bump quay.io/kubevirt/libguestfs-tools image to v0.52.0
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubevirt/kubevirt-tekton-tasks/issues/113

**Release note**:
```
Bump quay.io/kubevirt/libguestfs-tools image to v0.52.0
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
