### PR TITLE
Add missing defaults to modify-vm-template manifest

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1001,18 +1001,23 @@ spec:
     - name: templateNamespace
       description: Namespace of an source OpenShift template. (defaults to active namespace)
       type: string
+      default: ""
     - name: cpuSockets
       description: Number of CPU sockets
       type: string
+      default: "0"
     - name: cpuCores
       description: Number of CPU cores
       type: string
+      default: "0"
     - name: cpuThreads
       description: Number of CPU threads
       type: string
+      default: "0"
     - name: memory
       description: Number of memory vm can use
       type: string
+      default: ""
     - description: Template labels. If template contains same label, it will be replaced. Each param should have KEY:VAL format. Eg ["key:value", "key:value"].
       name: templateLabels
       type: array

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -24,18 +24,23 @@ spec:
     - name: templateNamespace
       description: Namespace of an source OpenShift template. (defaults to active namespace)
       type: string
+      default: ""
     - name: cpuSockets
       description: Number of CPU sockets
       type: string
+      default: "0"
     - name: cpuCores
       description: Number of CPU cores
       type: string
+      default: "0"
     - name: cpuThreads
       description: Number of CPU threads
       type: string
+      default: "0"
     - name: memory
       description: Number of memory vm can use
       type: string
+      default: ""
     - description: Template labels. If template contains same label, it will be replaced. Each param should have KEY:VAL format. Eg ["key:value", "key:value"].
       name: templateLabels
       type: array

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -24,18 +24,23 @@ spec:
     - name: templateNamespace
       description: Namespace of an source OpenShift template. (defaults to active namespace)
       type: string
+      default: ""
     - name: cpuSockets
       description: Number of CPU sockets
       type: string
+      default: "0"
     - name: cpuCores
       description: Number of CPU cores
       type: string
+      default: "0"
     - name: cpuThreads
       description: Number of CPU threads
       type: string
+      default: "0"
     - name: memory
       description: Number of memory vm can use
       type: string
+      default: ""
     - description: Template labels. If template contains same label, it will be replaced. Each param should have KEY:VAL format. Eg ["key:value", "key:value"].
       name: templateLabels
       type: array


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The manifest was missing defaults for several parameters, which made it
necessary to declare empty values for them when invoking the task.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing defaults for modify-vm-template task parameters
```
