### PR TITLE
add datavolumeTemplates parameter to modify-vm-template task

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1037,6 +1037,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - description: 'Datavolume templates in json format, replace datavolume if same name, otherwise new datavolume is appended. If deleteDatavolumeTemplate is set, first datavolumes are deleted and then datavolumes from this attribute are added. Eg [{"apiVersion": "cdi.kubevirt.io/v1beta1", "kind": "DataVolume", "metadata":{"name": "test1"}, "spec": {"source": {"http": {"url": "test.somenonexisting"}}}}]'
+      name: datavolumeTemplates
+      type: array
+      default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
       default: 'false'
@@ -1066,6 +1070,8 @@ spec:
         - $(params.disks)
         - "--volumes"
         - $(params.volumes)
+        - "--datavolumeTemplates"
+        - $(params.datavolumeTemplates)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)

--- a/modules/modify-vm-template/pkg/templates/template-provider.go
+++ b/modules/modify-vm-template/pkg/templates/template-provider.go
@@ -141,6 +141,19 @@ func (t *TemplateUpdator) setValuesToVM(vm *kubevirtv1.VirtualMachine) *kubevirt
 		deleteDatavolumeTemplateFromVM(vm)
 	}
 
+	for _, datavolumeTemplate := range t.cliOptions.GetDatavolumeTemplates() {
+		replaced := false
+		for i, vmDatavolumeTemplate := range vm.Spec.DataVolumeTemplates {
+			if datavolumeTemplate.Name == vmDatavolumeTemplate.Name {
+				vm.Spec.DataVolumeTemplates[i] = datavolumeTemplate
+				replaced = true
+			}
+		}
+		if !replaced {
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, datavolumeTemplate)
+		}
+	}
+
 	for _, disk := range t.cliOptions.GetDisks() {
 		replaced := false
 		for i, vmDisk := range vm.Spec.Template.Spec.Domain.Devices.Disks {

--- a/modules/tests/test/constants/modify-vm-template.go
+++ b/modules/tests/test/constants/modify-vm-template.go
@@ -1,7 +1,9 @@
 package constants
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
 const (
@@ -21,6 +23,7 @@ const (
 	VMAnnotationsOptionName       = "vmAnnotations"
 	DisksOptionName               = "disks"
 	VolumesOptionName             = "volumes"
+	DataVolumeTemplatesName       = "datavolumeTemplates"
 	DeleteDatavolumeTemplateName  = "deleteDatavolumeTemplate"
 
 	CPUSocketsTopologyNumber    uint32 = 1
@@ -38,8 +41,9 @@ var (
 	MockArray          = []string{"newKey: value", "test: true"}
 	WrongStrSlice      = []string{"wrong vaue"}
 
-	MockDisks   = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}", "{\"name\": \"containerdisk\", \"disk\": {\"bus\": \"sata\"}, \"bootOrder\": 2}"}
-	MockVolumes = []string{"{\"name\": \"containerdisk\", \"containerDisk\": {\"image\": \"URL\"}}", "{\"name\": \"cloudinitdisk\"}", "{\"name\": \"test3\"}"}
+	MockDisks               = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}", "{\"name\": \"containerdisk\", \"disk\": {\"bus\": \"sata\"}, \"bootOrder\": 2}"}
+	MockVolumes             = []string{"{\"name\": \"containerdisk\", \"containerDisk\": {\"image\": \"URL\"}}", "{\"name\": \"cloudinitdisk\"}", "{\"name\": \"test3\"}"}
+	MockDataVolumeTemplates = []string{"{\"apiVersion\": \"cdi.kubevirt.io/v1beta1\", \"kind\": \"DataVolume\", \"metadata\":{\"name\": \"test1\"}, \"spec\": {\"source\": {\"http\": {\"url\": \"test.somenonexisting\"}}}}"}
 
 	LabelsAnnotationsMap = map[string]string{
 		"newKey": "value",
@@ -84,6 +88,25 @@ var (
 		},
 		{
 			Name: "test3",
+		},
+	}
+
+	DataVolumeTemplates = []kubevirtv1.DataVolumeTemplateSpec{
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DataVolume",
+				APIVersion: "cdi.kubevirt.io/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test1",
+			},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: &cdiv1.DataVolumeSource{
+					HTTP: &cdiv1.DataVolumeSourceHTTP{
+						URL: "test.somenonexisting",
+					},
+				},
+			},
 		},
 	}
 )

--- a/modules/tests/test/testconfigs/modify-vm-template-test-config.go
+++ b/modules/tests/test/testconfigs/modify-vm-template-test-config.go
@@ -26,6 +26,7 @@ type ModifyTemplateTaskData struct {
 	VMLabels                 []string
 	Disks                    []string
 	Volumes                  []string
+	DataVolumeTemplates      []string
 	DeleteDatavolumeTemplate bool
 }
 
@@ -122,6 +123,12 @@ func (m *ModifyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			Value: v1beta1.ArrayOrString{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: m.TaskData.Volumes,
+			},
+		}, {
+			Name: DataVolumeTemplatesName,
+			Value: v1beta1.ArrayOrString{
+				Type:     v1beta1.ParamTypeArray,
+				ArrayVal: m.TaskData.DataVolumeTemplates,
 			},
 		}, {
 			Name: DeleteDatavolumeTemplateName,

--- a/tasks/modify-vm-template/README.md
+++ b/tasks/modify-vm-template/README.md
@@ -22,6 +22,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **vmAnnotations**: VM annotations. If VM contains same annotation, it will be replaced. Each param should have KEY:VAL format. Eg [`key:value`, `key:value`].
 - **disks**: VM disks in json format, replace vm disk if same name, otherwise new disk is appended. Eg [{`name`: `test`, `cdrom`: {`bus`: `sata`}}, {`name`: `disk2`}]
 - **volumes**: VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{`name`: `virtiocontainerdisk`, `containerDisk`: {`image`: `kubevirt/virtio-container-disk`}}]
+- **datavolumeTemplates**: Datavolume templates in json format, replace datavolume if same name, otherwise new datavolume is appended. If deleteDatavolumeTemplate is set, first datavolumes are deleted and then datavolumes from this attribute are added. Eg [{`apiVersion`: `cdi.kubevirt.io/v1beta1`, `kind`: `DataVolume`, `metadata`:{`name`: `test1`}, `spec`: {`source`: {`http`: {`url`: `test.somenonexisting`}}}}]
 - **deleteDatavolumeTemplate**: Set to `true` or `false` if task should delete datavolume template in template and all associated volumes and disks.
 
 ### Results

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -60,6 +60,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - description: 'Datavolume templates in json format, replace datavolume if same name, otherwise new datavolume is appended. If deleteDatavolumeTemplate is set, first datavolumes are deleted and then datavolumes from this attribute are added. Eg [{"apiVersion": "cdi.kubevirt.io/v1beta1", "kind": "DataVolume", "metadata":{"name": "test1"}, "spec": {"source": {"http": {"url": "test.somenonexisting"}}}}]'
+      name: datavolumeTemplates
+      type: array
+      default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
       default: 'false'
@@ -89,6 +93,8 @@ spec:
         - $(params.disks)
         - "--volumes"
         - $(params.volumes)
+        - "--datavolumeTemplates"
+        - $(params.datavolumeTemplates)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -60,6 +60,10 @@ spec:
       name: volumes
       type: array
       default: []
+    - description: 'Datavolume templates in json format, replace datavolume if same name, otherwise new datavolume is appended. If deleteDatavolumeTemplate is set, first datavolumes are deleted and then datavolumes from this attribute are added. Eg [{"apiVersion": "cdi.kubevirt.io/v1beta1", "kind": "DataVolume", "metadata":{"name": "test1"}, "spec": {"source": {"http": {"url": "test.somenonexisting"}}}}]'
+      name: datavolumeTemplates
+      type: array
+      default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
       default: 'false'
@@ -89,6 +93,8 @@ spec:
         - $(params.disks)
         - "--volumes"
         - $(params.volumes)
+        - "--datavolumeTemplates"
+        - $(params.datavolumeTemplates)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)


### PR DESCRIPTION
**What this PR does / why we need it**:
add datavolumeTemplates parameter to modify-vm-template task

This parameter can replace or add dataVolume template in vm definition.
If name is same, datavolume is replaced, if not, it is appended.
If deleteDatavolumeTemplate is set, first datavolumes are deleted
and then datavolumes from this attribute are added.

**Release note**:
```
add datavolumeTemplates parameter to modify-vm-template task
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
