### PR TITLE
Fix typo in modify-vm-template test

### DIFF
--- a/modules/tests/test/modify-vm-template_test.go
+++ b/modules/tests/test/modify-vm-template_test.go
@@ -492,7 +492,7 @@ var _ = Describe("Modify template task", func() {
 			Expect(err).ShouldNot(HaveOccurred(), "decode updated VM")
 
 			Expect(updatedTemplate.Labels).To(Equal(template.Labels), "templateLabels should be unchanged")
-			Expect(updatedTemplate.Annotations).To(Equal(updatedTemplate.Annotations), "templateAnnotations should be unchanged")
+			Expect(updatedTemplate.Annotations).To(Equal(template.Annotations), "templateAnnotations should be unchanged")
 			Expect(updatedVm.Spec.Template.Spec.Domain.CPU.Sockets).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Sockets), "cpuSockets should be unchanged")
 			Expect(updatedVm.Spec.Template.Spec.Domain.CPU.Cores).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Cores), "cpuCores should be unchanged")
 			Expect(updatedVm.Spec.Template.Spec.Domain.CPU.Threads).To(Equal(vm.Spec.Template.Spec.Domain.CPU.Threads), "cpuThreads should be unchanged")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Copy paste typo...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
