### PR TITLE
add param allowReplace in copy template task

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -140,6 +140,7 @@ metadata:
     targetTemplateName.params.task.kubevirt.io/kind: Template
     targetTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
     targetTemplateNamespace.params.task.kubevirt.io/type: namespace
+    allowReplace.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: copy-template
     task.kubevirt.io/category: copy-template
@@ -161,6 +162,10 @@ spec:
       description: Namespace of an target OpenShift template to create in. (defaults to active namespace)
       type: string
       default: ""
+    - name: allowReplace
+      description: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a template that was created.
@@ -182,6 +187,8 @@ spec:
           value: $(params.targetTemplateName)
         - name: TARGET_TEMPLATE_NAMESPACE
           value: $(params.targetTemplateNamespace)
+        - name: ALLOW_REPLACE
+          value: $(params.allowReplace)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -194,6 +201,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - template.openshift.io
     resources:

--- a/modules/copy-template/pkg/utils/parse/clioptions.go
+++ b/modules/copy-template/pkg/utils/parse/clioptions.go
@@ -17,13 +17,13 @@ const (
 )
 
 type CLIOptions struct {
-	SourceTemplateName      string `arg:"--source-template-name,env:SOURCE_TEMPLATE_NAME,required" placeholder:"NAME" help:"Name of a source template"`
-	SourceTemplateNamespace string `arg:"--source-template-namespace,env:SOURCE_TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a source template"`
-	TargetTemplateName      string `arg:"--target-template-name,env:TARGET_TEMPLATE_NAME" placeholder:"NAME" help:"Name of a target template"`
-	TargetTemplateNamespace string `arg:"--target-template-namespace,env:TARGET_TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a target template"`
-
-	Output output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
-	Debug  bool              `arg:"--debug" help:"Sets DEBUG log level"`
+	SourceTemplateName      string            `arg:"--source-template-name,env:SOURCE_TEMPLATE_NAME,required" placeholder:"NAME" help:"Name of a source template"`
+	SourceTemplateNamespace string            `arg:"--source-template-namespace,env:SOURCE_TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a source template"`
+	TargetTemplateName      string            `arg:"--target-template-name,env:TARGET_TEMPLATE_NAME" placeholder:"NAME" help:"Name of a target template"`
+	TargetTemplateNamespace string            `arg:"--target-template-namespace,env:TARGET_TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a target template"`
+	AllowReplace            string            `arg:"--allow-replace,env:ALLOW_REPLACE" placeholder:"false" help:"Allow replacing already existing template (same combination name/namespace). Allowed values true/false"`
+	Output                  output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
+	Debug                   bool              `arg:"--debug" help:"Sets DEBUG log level"`
 }
 
 func (c *CLIOptions) GetDebugLevel() zapcore.Level {
@@ -47,6 +47,10 @@ func (c *CLIOptions) GetTargetTemplateNamespace() string {
 
 func (c *CLIOptions) GetTargetTemplateName() string {
 	return c.TargetTemplateName
+}
+
+func (c *CLIOptions) GetAllowReplaceValue() bool {
+	return c.AllowReplace == "true"
 }
 
 func (c *CLIOptions) Init() error {

--- a/modules/copy-template/pkg/utils/parse/clioptions_test.go
+++ b/modules/copy-template/pkg/utils/parse/clioptions_test.go
@@ -55,6 +55,24 @@ var _ = Describe("CLIOptions", func() {
 				Output:                  "json",
 				Debug:                   true,
 			}),
+			Entry("with AllowReplace", &parse.CLIOptions{
+				SourceTemplateName:      testStringSourceName,
+				SourceTemplateNamespace: testStringSourceNamespace,
+				TargetTemplateName:      testStringTargetName,
+				TargetTemplateNamespace: testStringTargetNamespace,
+				AllowReplace:            "false",
+				Output:                  "json",
+				Debug:                   true,
+			}),
+			Entry("with AllowReplace", &parse.CLIOptions{
+				SourceTemplateName:      testStringSourceName,
+				SourceTemplateNamespace: testStringSourceNamespace,
+				TargetTemplateName:      testStringTargetName,
+				TargetTemplateNamespace: testStringTargetNamespace,
+				AllowReplace:            "true",
+				Output:                  "json",
+				Debug:                   true,
+			}),
 			Entry("no source-template-namespace", &parse.CLIOptions{SourceTemplateName: testStringSourceName}),
 			Entry("no target-template-name", &parse.CLIOptions{
 				SourceTemplateName:      testStringSourceName,
@@ -89,6 +107,14 @@ var _ = Describe("CLIOptions", func() {
 			Entry("GetSourceTemplateNamespace should return correct value", (&parse.CLIOptions{SourceTemplateNamespace: testStringSourceNamespace}).GetSourceTemplateNamespace, testStringSourceNamespace),
 			Entry("GetTargetTemplateNamespace should return correct value", (&parse.CLIOptions{TargetTemplateNamespace: testStringTargetNamespace}).GetTargetTemplateNamespace, testStringTargetNamespace),
 			Entry("GetTargetTemplateName should return correct value", (&parse.CLIOptions{TargetTemplateName: testStringTargetName}).GetTargetTemplateName, testStringTargetName),
+		)
+
+		DescribeTable("GetAllowReplaceValue should return correct values", func(fnToCall func() bool, result bool) {
+			Expect(fnToCall()).To(Equal(result), "result should equal")
+		},
+			Entry("should return correct true", (&parse.CLIOptions{AllowReplace: "true"}).GetAllowReplaceValue, true),
+			Entry("should return correct false", (&parse.CLIOptions{AllowReplace: "false"}).GetAllowReplaceValue, false),
+			Entry("should return correct false, when wrong string", (&parse.CLIOptions{AllowReplace: "notAValue"}).GetAllowReplaceValue, false),
 		)
 
 		DescribeTable("CLI options should return correct log level", func(options *parse.CLIOptions, level zapcore.Level) {

--- a/modules/tests/test/constants/copy-template.go
+++ b/modules/tests/test/constants/copy-template.go
@@ -10,4 +10,5 @@ const (
 	SourceTemplateNamespaceOptionName = "sourceTemplateNamespace"
 	TargetTemplateNameOptionName      = "targetTemplateName"
 	TargetTemplateNamespaceOptionName = "targetTemplateNamespace"
+	AllowReplaceOptionName            = "allowReplace"
 )

--- a/modules/tests/test/testconfigs/copy-template-config.go
+++ b/modules/tests/test/testconfigs/copy-template-config.go
@@ -17,6 +17,7 @@ type CopyTemplateTaskData struct {
 	TargetTemplateNamespace TargetNamespace
 	SourceNamespace         string
 	TargetNamespace         string
+	AllowReplace            string
 	TemplateNamespace       TargetNamespace
 }
 
@@ -73,6 +74,12 @@ func (c *CopyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			Value: v1beta1.ArrayOrString{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: c.TaskData.TargetNamespace,
+			},
+		}, {
+			Name: AllowReplaceOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: c.TaskData.AllowReplace,
 			},
 		},
 	}

--- a/tasks/copy-template/README.md
+++ b/tasks/copy-template/README.md
@@ -14,6 +14,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **sourceTemplateNamespace**: Namespace of an source OpenShift template to copy template from. (defaults to active namespace)
 - **targetTemplateName**: Name of an target OpenShift template.
 - **targetTemplateNamespace**: Namespace of an target OpenShift template to create in. (defaults to active namespace)
+- **allowReplace**: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
 
 ### Results
 

--- a/tasks/copy-template/manifests/copy-template.yaml
+++ b/tasks/copy-template/manifests/copy-template.yaml
@@ -10,6 +10,7 @@ metadata:
     targetTemplateName.params.task.kubevirt.io/kind: Template
     targetTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
     targetTemplateNamespace.params.task.kubevirt.io/type: namespace
+    allowReplace.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: copy-template
     task.kubevirt.io/category: copy-template
@@ -31,6 +32,10 @@ spec:
       description: Namespace of an target OpenShift template to create in. (defaults to active namespace)
       type: string
       default: ""
+    - name: allowReplace
+      description: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a template that was created.
@@ -52,6 +57,8 @@ spec:
           value: $(params.targetTemplateName)
         - name: TARGET_TEMPLATE_NAMESPACE
           value: $(params.targetTemplateNamespace)
+        - name: ALLOW_REPLACE
+          value: $(params.allowReplace)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -64,6 +71,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - template.openshift.io
     resources:

--- a/templates/copy-template/manifests/copy-template-role.yaml
+++ b/templates/copy-template/manifests/copy-template-role.yaml
@@ -9,6 +9,7 @@ rules:
       - list
       - watch
       - create
+      - update
     apiGroups:
       - template.openshift.io
     resources:

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -10,6 +10,7 @@ metadata:
     targetTemplateName.params.task.kubevirt.io/kind: {{ task_param_types.template_kind }}
     targetTemplateName.params.task.kubevirt.io/apiVersion: {{ task_param_types.template_version }}
     targetTemplateNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
+    allowReplace.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}
@@ -31,6 +32,10 @@ spec:
       description: Namespace of an target OpenShift template to create in. (defaults to active namespace)
       type: string
       default: ""
+    - name: allowReplace
+      description: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a template that was created.
@@ -52,3 +57,5 @@ spec:
           value: $(params.targetTemplateName)
         - name: TARGET_TEMPLATE_NAMESPACE
           value: $(params.targetTemplateNamespace)
+        - name: ALLOW_REPLACE
+          value: $(params.allowReplace)


### PR DESCRIPTION
**What this PR does / why we need it**:
add Param allowReplace in copy template task
When this param is set, task will not fail, when template already
exists, but it will update already existing template with newly copied template

**Release note**:
```
add param allowReplace in copy template task
```
