### PR TITLE
add new parameters to modify template task

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -989,6 +989,7 @@ metadata:
     cpuThreads.params.task.kubevirt.io/type: number
     memory.params.task.kubevirt.io/type: memory
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
+    deleteTemplateParameters.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -1038,6 +1039,10 @@ spec:
       name: disks
       type: array
       default: []
+    - name: deleteDisks
+      description: Set to "true" or "false" if task should delete VM disks. New disks (from disks parameter) are applied, after old disks are deleted.
+      default: 'false'
+      type: string
     - description: 'VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{"name": "virtiocontainerdisk", "containerDisk": {"image": "kubevirt/virtio-container-disk"}}]'
       name: volumes
       type: array
@@ -1048,6 +1053,18 @@ spec:
       default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
+    - name: deleteVolumes
+      description: Set to "true" or "false" if task should delete VM volumes. New volumes (from volumes parameter) are applied, after old volumes are deleted.
+      default: 'false'
+      type: string
+    - name: templateParameters
+      description: 'Definition of template parameters. Eg [{"description": "VM name", "name": "NAME"}]'
+      default: []
+      type: array
+    - name: deleteTemplateParameters
+      description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
 
@@ -1077,6 +1094,8 @@ spec:
         - $(params.volumes)
         - "--datavolumeTemplates"
         - $(params.datavolumeTemplates)
+        - "--templateParameters"
+        - $(params.templateParameters)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)
@@ -1092,6 +1111,12 @@ spec:
           value: $(params.memory)
         - name: DELETE_DATAVOLUME_TEMPLATE
           value: $(params.deleteDatavolumeTemplate)
+        - name: DELETE_DISKS
+          value: $(params.deleteDisks)
+        - name: DELETE_VOLUMES
+          value: $(params.deleteVolumes)
+        - name: DELETE_TEMPLATE_PARAMETERS
+          value: $(params.deleteTemplateParameters)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
+++ b/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
@@ -24,6 +24,7 @@ var (
 	mockArray                 = []string{"newKey: value", "test: true"}
 	diskArray                 = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}"}
 	volumeArray               = []string{"{\"name\": \"test\", \"containerDisk\": {\"image\": \"URL\"}}"}
+	templateParametersArray   = []string{"{\"description\": \"VM name\", \"name\": \"NAME\"}"}
 	dataVolumeArray           = []string{"{\"apiVersion\": \"cdi.kubevirt.io/v1beta1\", \"kind\": \"DataVolume\", \"metadata\":{\"name\": \"test1\"}, \"spec\": {\"source\": {\"http\": {\"url\": \"test.somenonexisting\"}}}}"}
 	resultMap                 = map[string]string{"newKey": "value", "test": "true"}
 	testStringMemoryResource  = resource.MustParse(testStringMemory)
@@ -72,6 +73,7 @@ var _ = Describe("CLIOptions", func() {
 			Entry("wrong disk json", "invalid character 'w'", &parse.CLIOptions{TemplateName: testString, CPUCores: testNumberOfCPU, CPUThreads: testNumberOfCPU, TemplateLabels: mockArray, TemplateAnnotations: mockArray, VMLabels: mockArray, Disks: []string{"{wrongJson: value}"}}),
 			Entry("wrong volume json", "invalid character 'k'", &parse.CLIOptions{TemplateName: testString, CPUCores: testNumberOfCPU, CPUThreads: testNumberOfCPU, TemplateLabels: mockArray, TemplateAnnotations: mockArray, VMLabels: mockArray, Volumes: []string{"{key: value}"}}),
 			Entry("wrong dataVolumeTemplate json", "invalid character 'e' in literal true", &parse.CLIOptions{TemplateName: testString, CPUCores: testNumberOfCPU, CPUThreads: testNumberOfCPU, TemplateLabels: mockArray, TemplateAnnotations: mockArray, VMLabels: mockArray, Volumes: mockArray, DatavolumeTemplates: []string{"{wrong value}"}}),
+			Entry("wrong templateParameters json", "invalid character 'e' in literal true", &parse.CLIOptions{TemplateName: testString, CPUCores: testNumberOfCPU, CPUThreads: testNumberOfCPU, TemplateLabels: mockArray, TemplateAnnotations: mockArray, VMLabels: mockArray, Volumes: mockArray, DatavolumeTemplates: mockArray, TemplateParameters: []string{"{wrong value}"}}),
 		)
 	})
 	Context("correct cli options", func() {
@@ -98,8 +100,12 @@ var _ = Describe("CLIOptions", func() {
 				VMAnnotations:            mockArray,
 				Disks:                    diskArray,
 				Volumes:                  volumeArray,
+				DeleteVolumes:            true,
+				DeleteDisks:              true,
+				DeleteTemplateParameters: true,
 				DeleteDatavolumeTemplate: true,
 				DatavolumeTemplates:      dataVolumeArray,
+				TemplateParameters:       templateParametersArray,
 			}),
 		)
 
@@ -151,6 +157,9 @@ var _ = Describe("CLIOptions", func() {
 			Volumes:                  volumeArray,
 			DatavolumeTemplates:      dataVolumeArray,
 			DeleteDatavolumeTemplate: true,
+			DeleteDisks:              true,
+			DeleteVolumes:            true,
+			DeleteTemplateParameters: true,
 		}
 		DescribeTable("CLI options should return correct map of annotations / labels", func(obj *parse.CLIOptions, fnToCall func() map[string]string, result map[string]string) {
 			Expect(obj.Init()).To(Succeed(), "should succeeded")
@@ -189,11 +198,14 @@ var _ = Describe("CLIOptions", func() {
 			Entry("GetVolumes should return correct value", cli, cli.GetDatavolumeTemplates, parsedDataVolumeTemplates),
 		)
 
-		DescribeTable("CLI options should return correct value for DeleteDatavolumeTemplate", func(obj *parse.CLIOptions, fnToCall func() bool, result bool) {
+		DescribeTable("CLI options should return correct value for bool functions", func(obj *parse.CLIOptions, fnToCall func() bool, result bool) {
 			Expect(obj.Init()).To(Succeed(), "should succeeded")
 			Expect(fnToCall()).To(Equal(result), "bool should equal")
 		},
 			Entry("GetDeleteDatavolumeTemplate should return correct value", cli, cli.GetDeleteDatavolumeTemplate, true),
+			Entry("GetDeleteDisks should return correct value", cli, cli.GetDeleteDisks, true),
+			Entry("GetDeleteVolumes should return correct value", cli, cli.GetDeleteVolumes, true),
+			Entry("GetDeleteTemplateParameters should return correct value", cli, cli.GetDeleteTemplateParameters, true),
 		)
 	})
 })

--- a/modules/tests/test/constants/modify-vm-template.go
+++ b/modules/tests/test/constants/modify-vm-template.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	templatev1 "github.com/openshift/api/template/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -11,20 +12,24 @@ const (
 	ModifyTemplateServiceAccountName = "modify-vm-template-task"
 	ModifyTemplateTaskRunName        = "taskrun-modify-vm-template"
 
-	TemplateNameOptionName        = "templateName"
-	TemplateNamespaceOptionName   = "templateNamespace"
-	CPUCoresOptionName            = "cpuCores"
-	CPUSocketsOptionName          = "cpuSockets"
-	CPUThreadsOptionName          = "cpuThreads"
-	MemoryOptionName              = "memory"
-	TemplateLabelsOptionName      = "templateLabels"
-	TemplateAnnotationsOptionName = "templateAnnotations"
-	VMLabelsOptionName            = "vmLabels"
-	VMAnnotationsOptionName       = "vmAnnotations"
-	DisksOptionName               = "disks"
-	VolumesOptionName             = "volumes"
-	DataVolumeTemplatesName       = "datavolumeTemplates"
-	DeleteDatavolumeTemplateName  = "deleteDatavolumeTemplate"
+	TemplateNameOptionName             = "templateName"
+	TemplateNamespaceOptionName        = "templateNamespace"
+	CPUCoresOptionName                 = "cpuCores"
+	CPUSocketsOptionName               = "cpuSockets"
+	CPUThreadsOptionName               = "cpuThreads"
+	MemoryOptionName                   = "memory"
+	TemplateLabelsOptionName           = "templateLabels"
+	TemplateAnnotationsOptionName      = "templateAnnotations"
+	VMLabelsOptionName                 = "vmLabels"
+	VMAnnotationsOptionName            = "vmAnnotations"
+	DisksOptionName                    = "disks"
+	VolumesOptionName                  = "volumes"
+	DataVolumeTemplatesOptionName      = "datavolumeTemplates"
+	DeleteDatavolumeTemplateOptionName = "deleteDatavolumeTemplate"
+	DeleteDisksOptionName              = "deleteDisks"
+	DeleteVolumesOptionName            = "deleteVolumes"
+	DeleteTemplateParametersOptionName = "deleteTemplateParameters"
+	TemplateParametersOptionName       = "templateParameters"
 
 	CPUSocketsTopologyNumber    uint32 = 1
 	CPUCoresTopologyNumber      uint32 = 2
@@ -37,13 +42,15 @@ const (
 )
 
 var (
-	bootOrder     uint = 2
-	MockArray          = []string{"newKey: value", "test: true"}
-	WrongStrSlice      = []string{"wrong vaue"}
-
-	MockDisks               = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}", "{\"name\": \"containerdisk\", \"disk\": {\"bus\": \"sata\"}, \"bootOrder\": 2}"}
-	MockVolumes             = []string{"{\"name\": \"containerdisk\", \"containerDisk\": {\"image\": \"URL\"}}", "{\"name\": \"cloudinitdisk\"}", "{\"name\": \"test3\"}"}
-	MockDataVolumeTemplates = []string{"{\"apiVersion\": \"cdi.kubevirt.io/v1beta1\", \"kind\": \"DataVolume\", \"metadata\":{\"name\": \"test1\"}, \"spec\": {\"source\": {\"http\": {\"url\": \"test.somenonexisting\"}}}}"}
+	bootOrder               uint = 2
+	MockArray                    = []string{"newKey: value", "test: true"}
+	WrongStrSlice                = []string{"wrong value"}
+	MockDisk                     = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}"}
+	MockDisks                    = []string{"{\"name\": \"test\", \"cdrom\": {\"bus\": \"sata\"}}", "{\"name\": \"containerdisk\", \"disk\": {\"bus\": \"sata\"}, \"bootOrder\": 2}"}
+	MockVolume                   = []string{"{\"name\": \"test3\"}"}
+	MockVolumes                  = []string{"{\"name\": \"containerdisk\", \"containerDisk\": {\"image\": \"URL\"}}", "{\"name\": \"cloudinitdisk\"}", "{\"name\": \"test3\"}"}
+	MockDataVolumeTemplates      = []string{"{\"apiVersion\": \"cdi.kubevirt.io/v1beta1\", \"kind\": \"DataVolume\", \"metadata\":{\"name\": \"test1\"}, \"spec\": {\"source\": {\"http\": {\"url\": \"test.somenonexisting\"}}}}"}
+	MockTemplateParameter        = []string{"{\"name\": \"test\", \"value\": \"test\"}"}
 
 	LabelsAnnotationsMap = map[string]string{
 		"newKey": "value",
@@ -74,6 +81,18 @@ var (
 			},
 		},
 	}
+	Disk = kubevirtv1.Disk{
+		Name: "test",
+		DiskDevice: kubevirtv1.DiskDevice{
+			CDRom: &kubevirtv1.CDRomTarget{
+				Bus: "sata",
+			},
+		},
+	}
+	Volume = kubevirtv1.Volume{
+		Name: "test3",
+	}
+
 	Volumes = []kubevirtv1.Volume{
 		{
 			Name: "containerdisk",
@@ -88,6 +107,13 @@ var (
 		},
 		{
 			Name: "test3",
+		},
+	}
+
+	TemplateParameters = []templatev1.Parameter{
+		{
+			Name:  "test",
+			Value: "test",
 		},
 	}
 

--- a/modules/tests/test/create_vm_common_test.go
+++ b/modules/tests/test/create_vm_common_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Create VM", func() {
 							Eventually(func() bool {
 								dv, _ := f.CdiClient.DataVolumes(dv.Data.Namespace).Get(context.TODO(), dv.Data.Name, v1.GetOptions{})
 								return dv.Status.Phase == v1beta1cdi.Succeeded
-							}, time.Second*180, time.Second).Should(BeTrue(), dv.Data.Name+" datavolume should be ready")
+							}, time.Second*360, time.Second).Should(BeTrue(), dv.Data.Name+" datavolume should be ready")
 						}
 
 						expectedVM := config.TaskData.GetExpectedVMStubMeta()
@@ -274,7 +274,7 @@ var _ = Describe("Create VM", func() {
 				Eventually(func() bool {
 					dv, _ := f.CdiClient.DataVolumes(dv.Data.Namespace).Get(context.TODO(), dv.Data.Name, v1.GetOptions{})
 					return dv.Status.Phase == v1beta1cdi.Succeeded
-				}, time.Second*180, time.Second).Should(BeTrue(), dv.Data.Name+" datavolume should be ready")
+				}, time.Second*360, time.Second).Should(BeTrue(), dv.Data.Name+" datavolume should be ready")
 			}
 
 			expectedVM := config.TaskData.GetExpectedVMStubMeta()

--- a/modules/tests/test/testconfigs/modify-vm-template-test-config.go
+++ b/modules/tests/test/testconfigs/modify-vm-template-test-config.go
@@ -27,7 +27,11 @@ type ModifyTemplateTaskData struct {
 	Disks                    []string
 	Volumes                  []string
 	DataVolumeTemplates      []string
+	TemplateParameters       []string
 	DeleteDatavolumeTemplate bool
+	DeleteDisks              bool
+	DeleteVolumes            bool
+	DeleteTemplateParameters bool
 }
 
 type ModifyTemplateTestConfig struct {
@@ -125,16 +129,40 @@ func (m *ModifyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 				ArrayVal: m.TaskData.Volumes,
 			},
 		}, {
-			Name: DataVolumeTemplatesName,
+			Name: DataVolumeTemplatesOptionName,
 			Value: v1beta1.ArrayOrString{
 				Type:     v1beta1.ParamTypeArray,
 				ArrayVal: m.TaskData.DataVolumeTemplates,
 			},
 		}, {
-			Name: DeleteDatavolumeTemplateName,
+			Name: TemplateParametersOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:     v1beta1.ParamTypeArray,
+				ArrayVal: m.TaskData.TemplateParameters,
+			},
+		}, {
+			Name: DeleteDatavolumeTemplateOptionName,
 			Value: v1beta1.ArrayOrString{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: strconv.FormatBool(m.TaskData.DeleteDatavolumeTemplate),
+			},
+		}, {
+			Name: DeleteDisksOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: strconv.FormatBool(m.TaskData.DeleteDisks),
+			},
+		}, {
+			Name: DeleteVolumesOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: strconv.FormatBool(m.TaskData.DeleteVolumes),
+			},
+		}, {
+			Name: DeleteTemplateParametersOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: strconv.FormatBool(m.TaskData.DeleteTemplateParameters),
 			},
 		},
 	}

--- a/tasks/modify-vm-template/README.md
+++ b/tasks/modify-vm-template/README.md
@@ -21,9 +21,13 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **vmLabels**: VM labels. If VM contains same label, it will be replaced. Each param should have KEY:VAL format. Eg [`key:value`, `key:value`].
 - **vmAnnotations**: VM annotations. If VM contains same annotation, it will be replaced. Each param should have KEY:VAL format. Eg [`key:value`, `key:value`].
 - **disks**: VM disks in json format, replace vm disk if same name, otherwise new disk is appended. Eg [{`name`: `test`, `cdrom`: {`bus`: `sata`}}, {`name`: `disk2`}]
+- **deleteDisks**: Set to `true` or `false` if task should delete VM disks. New disks (from disks parameter) are applied, after old disks are deleted.
 - **volumes**: VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{`name`: `virtiocontainerdisk`, `containerDisk`: {`image`: `kubevirt/virtio-container-disk`}}]
 - **datavolumeTemplates**: Datavolume templates in json format, replace datavolume if same name, otherwise new datavolume is appended. If deleteDatavolumeTemplate is set, first datavolumes are deleted and then datavolumes from this attribute are added. Eg [{`apiVersion`: `cdi.kubevirt.io/v1beta1`, `kind`: `DataVolume`, `metadata`:{`name`: `test1`}, `spec`: {`source`: {`http`: {`url`: `test.somenonexisting`}}}}]
 - **deleteDatavolumeTemplate**: Set to `true` or `false` if task should delete datavolume template in template and all associated volumes and disks.
+- **deleteVolumes**: Set to `true` or `false` if task should delete VM volumes. New volumes (from volumes parameter) are applied, after old volumes are deleted.
+- **templateParameters**: Definition of template parameters. Eg [{`description`: `VM name`, `name`: `NAME`}]
+- **deleteTemplateParameters**: Set to `true` or `false` if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
 
 ### Results
 

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -12,6 +12,7 @@ metadata:
     cpuThreads.params.task.kubevirt.io/type: number
     memory.params.task.kubevirt.io/type: memory
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
+    deleteTemplateParameters.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -61,6 +62,10 @@ spec:
       name: disks
       type: array
       default: []
+    - name: deleteDisks
+      description: Set to "true" or "false" if task should delete VM disks. New disks (from disks parameter) are applied, after old disks are deleted.
+      default: 'false'
+      type: string
     - description: 'VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{"name": "virtiocontainerdisk", "containerDisk": {"image": "kubevirt/virtio-container-disk"}}]'
       name: volumes
       type: array
@@ -71,6 +76,18 @@ spec:
       default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
+    - name: deleteVolumes
+      description: Set to "true" or "false" if task should delete VM volumes. New volumes (from volumes parameter) are applied, after old volumes are deleted.
+      default: 'false'
+      type: string
+    - name: templateParameters
+      description: 'Definition of template parameters. Eg [{"description": "VM name", "name": "NAME"}]'
+      default: []
+      type: array
+    - name: deleteTemplateParameters
+      description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
 
@@ -100,6 +117,8 @@ spec:
         - $(params.volumes)
         - "--datavolumeTemplates"
         - $(params.datavolumeTemplates)
+        - "--templateParameters"
+        - $(params.templateParameters)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)
@@ -115,6 +134,12 @@ spec:
           value: $(params.memory)
         - name: DELETE_DATAVOLUME_TEMPLATE
           value: $(params.deleteDatavolumeTemplate)
+        - name: DELETE_DISKS
+          value: $(params.deleteDisks)
+        - name: DELETE_VOLUMES
+          value: $(params.deleteVolumes)
+        - name: DELETE_TEMPLATE_PARAMETERS
+          value: $(params.deleteTemplateParameters)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -12,6 +12,7 @@ metadata:
     cpuThreads.params.task.kubevirt.io/type: {{ task_param_types.number }}
     memory.params.task.kubevirt.io/type: {{ task_param_types.memory }}
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    deleteTemplateParameters.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}
@@ -61,6 +62,10 @@ spec:
       name: disks
       type: array
       default: []
+    - name: deleteDisks
+      description: Set to "true" or "false" if task should delete VM disks. New disks (from disks parameter) are applied, after old disks are deleted.
+      default: 'false'
+      type: string
     - description: 'VM volumes in json format, replace vm volume if same name, otherwise new volume is appended. Eg [{"name": "virtiocontainerdisk", "containerDisk": {"image": "kubevirt/virtio-container-disk"}}]'
       name: volumes
       type: array
@@ -71,6 +76,18 @@ spec:
       default: []
     - name: deleteDatavolumeTemplate
       description: Set to "true" or "false" if task should delete datavolume template in template and all associated volumes and disks.
+      default: 'false'
+      type: string
+    - name: deleteVolumes
+      description: Set to "true" or "false" if task should delete VM volumes. New volumes (from volumes parameter) are applied, after old volumes are deleted.
+      default: 'false'
+      type: string
+    - name: templateParameters
+      description: 'Definition of template parameters. Eg [{"description": "VM name", "name": "NAME"}]'
+      default: []
+      type: array
+    - name: deleteTemplateParameters
+      description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
 
@@ -100,6 +117,8 @@ spec:
         - $(params.volumes)
         - "--datavolumeTemplates"
         - $(params.datavolumeTemplates)
+        - "--templateParameters"
+        - $(params.templateParameters)
       env:
         - name: TEMPLATE_NAME
           value: $(params.templateName)
@@ -115,3 +134,9 @@ spec:
           value: $(params.memory)
         - name: DELETE_DATAVOLUME_TEMPLATE
           value: $(params.deleteDatavolumeTemplate)
+        - name: DELETE_DISKS
+          value: $(params.deleteDisks)
+        - name: DELETE_VOLUMES
+          value: $(params.deleteVolumes)
+        - name: DELETE_TEMPLATE_PARAMETERS
+          value: $(params.deleteTemplateParameters)


### PR DESCRIPTION
**What this PR does / why we need it**:
add new parameters to modify template task

this PR adds these params:
deleteVolumes: delete all VM volumes
deleteDisks: delete all VM disks
deleteTemplateParameters: delete all template parameters.
templateParameters: adds new template parameters

If delete params are set, volumes, disks, template params are added
after deletion
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
added new parameters to modify template task:
deleteVolumes: delete all VM volumes
deleteDisks: delete all VM disks
deleteTemplateParameters: delete all template parameters.
templateParameters: adds new template parameters
```
