### PR TITLE
fix getting of kubevirt components latest release

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -6,23 +6,24 @@ if kubectl get namespace tekton-pipelines > /dev/null 2>&1; then
   exit 0
 fi
 
-KUBEVIRT_VERSION=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-CDI_VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-COMMON_TEMPLATES_VERSION=""
+KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
+CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
+TEKTON_VERSION=$(curl -s https://api.github.com/repos/tektoncd/operator/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+
 if kubectl get templates > /dev/null 2>&1; then
   # okd
-  COMMON_TEMPLATES_VERSION=$(curl -s https://github.com/kubevirt/common-templates/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
-
-  # Prepare Tekton Pipelines
-  oc new-project tekton-pipelines
-  oc adm policy add-scc-to-user anyuid -z tekton-pipelines-controller
-  oc adm policy add-scc-to-user anyuid -z tekton-pipelines-webhook
+  COMMON_TEMPLATES_VERSION=$(curl -s https://api.github.com/repos/kubevirt/common-templates/releases | \
+            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+  oc apply -n openshift -f "https://github.com/kubevirt/common-templates/releases/download/${COMMON_TEMPLATES_VERSION}/common-templates.yaml"
 fi
 
-
 # Deploy Tekton Pipelines
-kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
-kubectl config set-context --current --namespace=default
+oc apply -f "https://github.com/tektoncd/operator/releases/download/${TEKTON_VERSION}/openshift-release.yaml"
 
 # Deploy Kubevirt
 kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
@@ -36,15 +37,8 @@ kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releas
 
 kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
 
-# Deploy Common Templates
-
-if [ -n "${COMMON_TEMPLATES_VERSION}" ]; then
-  kubectl apply -n openshift -f "https://github.com/kubevirt/common-templates/releases/download/${COMMON_TEMPLATES_VERSION}/common-templates.yaml"
-fi
-
 # wait for tekton pipelines
-kubectl rollout status -n tekton-pipelines deployment/tekton-pipelines-controller --timeout 10m
-kubectl rollout status -n tekton-pipelines deployment/tekton-pipelines-webhook --timeout 10m
+oc rollout status -n openshift-operators deployment/openshift-pipelines-operator --timeout 10m
 
 # Wait for kubevirt to be available
 kubectl rollout status -n cdi deployment/cdi-operator --timeout 10m


### PR DESCRIPTION
**What this PR does / why we need it**:
fix getting of kubevirt components latest release
previous command fetched latest releases according to date.
Current command fetch latest release according to version number.

**Release note**:
```
NONE
```
