### PR TITLE
add RunStrategy parameter to create vm tasks

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -263,7 +263,11 @@ spec:
       default: ""
       type: string
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -309,6 +313,8 @@ spec:
           value: $(params.namespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -360,7 +360,11 @@ spec:
       default: ""
       type: string
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -406,6 +410,8 @@ spec:
           value: $(params.namespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -510,7 +516,11 @@ spec:
       default: ""
       type: string
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -560,6 +570,8 @@ spec:
           value: $(params.vmNamespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/create-vm/cmd/create-vm/main.go
+++ b/modules/create-vm/cmd/create-vm/main.go
@@ -13,6 +13,7 @@ import (
 	res "github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/results"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/zerrors"
 	"go.uber.org/zap"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 )
 
 func main() {
@@ -50,8 +51,8 @@ func main() {
 	if err := vmCreator.OwnVolumes(vm); err != nil {
 		exit.ExitFromError(OwnVolumesErrorExitCode, err)
 	}
-
-	if cliOptions.GetStartVMFlag() {
+	runStrategy := cliOptions.GetRunStrategy()
+	if cliOptions.GetStartVMFlag() && kubevirtv1.RunStrategyAlways != kubevirtv1.VirtualMachineRunStrategy(runStrategy) {
 		err := vmCreator.StartVM(vm.Namespace, vm.Name)
 		if err != nil {
 			exit.ExitFromError(StartVMErrorExitCode, err)

--- a/modules/create-vm/pkg/utils/parse/clioptions.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions.go
@@ -32,6 +32,7 @@ type CLIOptions struct {
 	PersistentVolumeClaims    []string          `arg:"--pvcs" placeholder:"PVC1 VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
 	OwnPersistentVolumeClaims []string          `arg:"--own-pvcs" placeholder:"PVC1  VOLUME_NAME:PVC2 PVC3" help:"Add PersistentVolumeClaims to VM Volumes and add VM to PVC ownerReferences. These PVCs will be deleted once the created VM gets deleted. Replaces a particular volume if in PVC_NAME:DV_NAME format."`
 	StartVM                   string            `arg:"--start-vm,env:START_VM" help:"Start vm after creation"`
+	RunStrategy               string            `arg:"--run-strategy,env:RUN_STRATEGY" help:"Set run strategy to vm"`
 	Output                    output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug                     bool              `arg:"--debug" help:"Sets DEBUG log level"`
 }
@@ -54,6 +55,10 @@ func (c *CLIOptions) GetOwnDVNames() []string {
 
 func (c *CLIOptions) GetStartVMFlag() bool {
 	return c.StartVM == "true"
+}
+
+func (c *CLIOptions) GetRunStrategy() string {
+	return c.RunStrategy
 }
 
 func (c *CLIOptions) GetPVCDiskNamesMap() map[string]string {

--- a/modules/create-vm/pkg/utils/parse/clioptions_test.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions_test.go
@@ -79,6 +79,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetDebugLevel":              zapcore.InfoLevel,
 			"GetCreationMode":            constants.TemplateCreationMode,
 			"GetStartVMFlag":             false,
+			"GetRunStrategy":             "",
 		}),
 		Entry("handles template cli arguments", &parse.CLIOptions{
 			TemplateName:              "test",
@@ -92,6 +93,7 @@ var _ = Describe("CLIOptions", func() {
 			OwnDataVolumes:            []string{"mydisk3:dv3", "dv4", "mydisk4:dv5"},
 			Debug:                     true,
 			StartVM:                   "true",
+			RunStrategy:               "Always",
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       defaultNS,
 			"GetVirtualMachineNamespace": defaultNS,
@@ -119,6 +121,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetDebugLevel":   zapcore.DebugLevel,
 			"GetCreationMode": constants.TemplateCreationMode,
 			"GetStartVMFlag":  true,
+			"GetRunStrategy":  "Always",
 		}),
 		Entry("handles vm cli arguments", &parse.CLIOptions{
 			VirtualMachineManifest:    testVMManifest,
@@ -130,6 +133,7 @@ var _ = Describe("CLIOptions", func() {
 			OwnDataVolumes:            []string{"dv3"},
 			Debug:                     true,
 			StartVM:                   "false",
+			RunStrategy:               "Always",
 		}, map[string]interface{}{
 			"GetTemplateNamespace":       "",
 			"GetVirtualMachineNamespace": defaultNS,
@@ -152,6 +156,7 @@ var _ = Describe("CLIOptions", func() {
 			"GetDebugLevel":     zapcore.DebugLevel,
 			"GetCreationMode":   constants.VMManifestCreationMode,
 			"GetStartVMFlag":    false,
+			"GetRunStrategy":    "Always",
 		}),
 		Entry("handles trim", &parse.CLIOptions{
 			TemplateName:              "test",

--- a/modules/create-vm/pkg/vmcreator/vm-creator.go
+++ b/modules/create-vm/pkg/vmcreator/vm-creator.go
@@ -97,6 +97,12 @@ func (v *VMCreator) createVMFromManifest() (*kubevirtv1.VirtualMachine, error) {
 	templateValidations := validations.NewTemplateValidations(nil) // fallback to defaults
 	virtualMachine.AddVolumes(&vm, templateValidations, v.cliOptions)
 
+	runStrategy := kubevirtv1.VirtualMachineRunStrategy(v.cliOptions.GetRunStrategy())
+	if runStrategy != "" {
+		vm.Spec.Running = nil
+		vm.Spec.RunStrategy = &runStrategy
+	}
+
 	log.Logger().Debug("creating VM", zap.Reflect("vm", vm))
 	return v.virtualMachineProvider.Create(v.targetNamespace, &vm)
 }
@@ -131,6 +137,12 @@ func (v *VMCreator) createVMFromTemplate() (*kubevirtv1.VirtualMachine, error) {
 
 	virtualMachine.AddMetadata(vm, processedTemplate)
 	virtualMachine.AddVolumes(vm, templateValidations, v.cliOptions)
+
+	runStrategy := kubevirtv1.VirtualMachineRunStrategy(v.cliOptions.GetRunStrategy())
+	if runStrategy != "" {
+		vm.Spec.Running = nil
+		vm.Spec.RunStrategy = &runStrategy
+	}
 
 	log.Logger().Debug("creating VM", zap.Reflect("vm", vm))
 	return v.virtualMachineProvider.Create(v.targetNamespace, vm)

--- a/modules/tests/test/constants/create-vm.go
+++ b/modules/tests/test/constants/create-vm.go
@@ -24,6 +24,7 @@ type createVMFromTemplateParams struct {
 	TemplateParams    string
 	VmNamespace       string
 	StartVM           string
+	RunStrategy       string
 }
 
 var CreateVMParams = createVMParams{
@@ -44,6 +45,7 @@ var CreateVMFromTemplateParams = createVMFromTemplateParams{
 	TemplateParams:    "templateParams",
 	VmNamespace:       "vmNamespace",
 	StartVM:           "startVM",
+	RunStrategy:       "runStrategy",
 }
 
 type createVMResults struct {

--- a/modules/tests/test/testconfigs/vm-test-config.go
+++ b/modules/tests/test/testconfigs/vm-test-config.go
@@ -33,6 +33,7 @@ type CreateVMTaskData struct {
 	UseDefaultTemplateNamespacesInTaskParams bool
 	UseDefaultVMNamespacesInTaskParams       bool
 	StartVM                                  string
+	RunStrategy                              string
 	ExpectedAdditionalDiskBus                string
 
 	// Params
@@ -322,6 +323,13 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			Value: v1beta1.ArrayOrString{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: c.TaskData.StartVM,
+			},
+		},
+		{
+			Name: CreateVMFromTemplateParams.RunStrategy,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: c.TaskData.RunStrategy,
 			},
 		},
 	}

--- a/tasks/create-vm-from-manifest/README.md
+++ b/tasks/create-vm-from-manifest/README.md
@@ -11,7 +11,8 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 
 - **manifest**: YAML manifest of a VirtualMachine resource to be created.
 - **namespace**: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
-- **startVM**: Set to true or false to start / not start vm after creation.
+- **startVM**: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+- **runStrategy**: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
 - **dataVolumes**: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **ownDataVolumes**: Add DVs to VM Volumes and add VM to DV ownerReferences. These DataVolumes will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **persistentVolumeClaims**: Add PVCs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:PVC_NAME format. Eg. `["rootdisk:my-pvc", "my-pvc2"]`

--- a/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
@@ -31,7 +31,11 @@ spec:
       default: ""
       type: string
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -77,6 +81,8 @@ spec:
           value: $(params.namespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tasks/create-vm-from-template/README.md
+++ b/tasks/create-vm-from-template/README.md
@@ -15,7 +15,8 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **templateNamespace**: Namespace of an OKD template to create VM from. (defaults to active namespace)
 - **templateParams**: Template params to pass when processing the template manifest. Each param should have KEY:VAL format. Eg `["NAME:my-vm", "DESC:blue"]`
 - **vmNamespace**: Namespace where to create the VM. (defaults to active namespace)
-- **startVM**: Set to true or false to start / not start vm after creation.
+- **startVM**: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+- **runStrategy**: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
 - **dataVolumes**: Add DVs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **ownDataVolumes**: Add DVs to VM Volumes and add VM to DV ownerReferences. These DataVolumes will be deleted once the created VM gets deleted. Replaces a particular volume if in VOLUME_NAME:DV_NAME format. Eg. `["rootdisk:my-dv", "my-dv2"]`
 - **persistentVolumeClaims**: Add PVCs to VM Volumes. Replaces a particular volume if in VOLUME_NAME:PVC_NAME format. Eg. `["rootdisk:my-pvc", "my-pvc2"]`

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -41,7 +41,11 @@ spec:
       default: ""
       type: string
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -91,6 +95,8 @@ spec:
           value: $(params.vmNamespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -58,7 +58,11 @@ spec:
       type: string
 {% endif %}
     - name: startVM
-      description: Set to true or false to start / not start vm after creation.
+      description: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
+      default: ""
+      type: string
+    - name: runStrategy
+      description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
     - name: dataVolumes
@@ -116,3 +120,5 @@ spec:
 {% endif %}
         - name: START_VM
           value: $(params.startVM)
+        - name: RUN_STRATEGY
+          value: $(params.runStrategy)


### PR DESCRIPTION
**What this PR does / why we need it**:
add RunStrategy parameter to create vm tasks
if runStrategy param is set, vm.spec.running is set to nil, due to https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go#L315
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Special notes for your reviewer**:

**Release note**:
```
add runStrategy parameter for create-vm tasks

```
