### PR TITLE
Allow create-datavolume-from-manifest-role to create pods

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -211,6 +211,12 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - pods
 
 ---
 apiVersion: v1

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -308,6 +308,12 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - pods
 
 ---
 apiVersion: v1

--- a/tasks/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest.yaml
+++ b/tasks/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest.yaml
@@ -81,6 +81,12 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - pods
 
 ---
 apiVersion: v1

--- a/templates/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest-role.yaml
+++ b/templates/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest-role.yaml
@@ -13,3 +13,9 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - pods


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed to allow cloning of DataVolumes.

See https://github.com/kubevirt/containerized-data-importer/blob/f9d4a4b4c8b17ddab992063be1531fad3b47f44a/pkg/clone/auth.go#L124

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
