### PR TITLE
remove all common-template labels / annotations in copy task

### DIFF
--- a/modules/copy-template/pkg/templates/common-templates.go
+++ b/modules/copy-template/pkg/templates/common-templates.go
@@ -1,0 +1,31 @@
+package templates
+
+const (
+	OpenshiftDocURL              = "openshift.io/documentation-url"
+	OpenshiftProviderDisplayName = "openshift.io/provider-display-name"
+	OpenshiftSupportURL          = "openshift.io/support-url"
+
+	KubevirtDefaultOSVariant = "template.kubevirt.io/default-os-variant"
+
+	TemplateKubevirtProvider             = "template.kubevirt.io/provider"
+	TemplateKubevirtProviderSupportLevel = "template.kubevirt.io/provider-support-level"
+	TemplateKubevirtProviderURL          = "template.kubevirt.io/provider-url"
+
+	OperatorSDKPrimaryResource     = "operator-sdk/primary-resource"
+	OperatorSDKPrimaryResourceType = "operator-sdk/primary-resource-type"
+
+	AppKubernetesComponent = "app.kubernetes.io/component"
+	AppKubernetesManagedBy = "app.kubernetes.io/managed-by"
+	AppKubernetesName      = "app.kubernetes.io/name"
+	AppKubernetesPartOf    = "app.kubernetes.io/part-of"
+	AppKubernetesVersion   = "app.kubernetes.io/version"
+
+	TemplateVersionLabel         = "template.kubevirt.io/version"
+	TemplateTypeLabel            = "template.kubevirt.io/type"
+	TemplateOsLabelPrefix        = "os.template.kubevirt.io/"
+	TemplateFlavorLabelPrefix    = "flavor.template.kubevirt.io/"
+	TemplateWorkloadLabelPrefix  = "workload.template.kubevirt.io/"
+	TemplateDeprecatedAnnotation = "template.kubevirt.io/deprecated"
+
+	templateTypeBaseValue = "base"
+)

--- a/modules/copy-template/pkg/templates/template-provider.go
+++ b/modules/copy-template/pkg/templates/template-provider.go
@@ -84,6 +84,11 @@ func (t *TemplateCreator) CopyTemplate() (*v1.Template, error) {
 }
 
 func (t *TemplateCreator) UpdateTemplateMetaObject(template *v1.Template) *v1.Template {
+	if isCommonTemplate(template) {
+		removeCommonTemplateInformations(template.Labels)
+		removeCommonTemplateInformations(template.Annotations)
+	}
+
 	newObjectMeta := metav1.ObjectMeta{
 		Namespace:   t.cliOptions.GetTargetTemplateNamespace(),
 		Labels:      template.Labels,
@@ -98,4 +103,38 @@ func (t *TemplateCreator) UpdateTemplateMetaObject(template *v1.Template) *v1.Te
 
 	template.ObjectMeta = newObjectMeta
 	return template
+}
+
+func isCommonTemplate(template *v1.Template) bool {
+	if val, ok := template.Labels[TemplateTypeLabel]; ok && val == templateTypeBaseValue {
+		return true
+	}
+	return false
+}
+
+func removeCommonTemplateInformations(obj map[string]string) {
+	delete(obj, TemplateVersionLabel)
+	delete(obj, TemplateTypeLabel)
+	delete(obj, TemplateOsLabelPrefix)
+	delete(obj, TemplateFlavorLabelPrefix)
+	delete(obj, TemplateWorkloadLabelPrefix)
+	delete(obj, TemplateDeprecatedAnnotation)
+	delete(obj, KubevirtDefaultOSVariant)
+
+	delete(obj, OpenshiftDocURL)
+	delete(obj, OpenshiftProviderDisplayName)
+	delete(obj, OpenshiftSupportURL)
+
+	delete(obj, TemplateKubevirtProvider)
+	delete(obj, TemplateKubevirtProviderSupportLevel)
+	delete(obj, TemplateKubevirtProviderURL)
+
+	delete(obj, OperatorSDKPrimaryResource)
+	delete(obj, OperatorSDKPrimaryResourceType)
+
+	delete(obj, AppKubernetesComponent)
+	delete(obj, AppKubernetesName)
+	delete(obj, AppKubernetesPartOf)
+	delete(obj, AppKubernetesVersion)
+	delete(obj, AppKubernetesManagedBy)
 }

--- a/modules/copy-template/pkg/templates/template-provider_test.go
+++ b/modules/copy-template/pkg/templates/template-provider_test.go
@@ -1,0 +1,85 @@
+package templates_test
+
+import (
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/copy-template/pkg/templates"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/template/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Template provider", func() {
+	Context("Common templates informations removed", func() {
+		It("should remove Common template informations", func() {
+			tProvider := &templates.TemplateCreator{}
+			t := &v1.Template{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						templates.OpenshiftDocURL:                      "test",
+						templates.OpenshiftProviderDisplayName:         "test",
+						templates.OpenshiftSupportURL:                  "test",
+						templates.KubevirtDefaultOSVariant:             "test",
+						templates.TemplateKubevirtProvider:             "test",
+						templates.TemplateKubevirtProviderSupportLevel: "test",
+						templates.TemplateKubevirtProviderURL:          "test",
+						templates.OperatorSDKPrimaryResource:           "test",
+						templates.OperatorSDKPrimaryResourceType:       "test",
+						templates.AppKubernetesComponent:               "test",
+						templates.AppKubernetesManagedBy:               "test",
+						templates.AppKubernetesName:                    "test",
+						templates.AppKubernetesPartOf:                  "test",
+						templates.AppKubernetesVersion:                 "test",
+						templates.TemplateVersionLabel:                 "test",
+						templates.TemplateTypeLabel:                    "test",
+						templates.TemplateOsLabelPrefix:                "test",
+						templates.TemplateFlavorLabelPrefix:            "test",
+						templates.TemplateWorkloadLabelPrefix:          "test",
+						templates.TemplateDeprecatedAnnotation:         "test",
+						"someOtherLabel":                               "test",
+					},
+					Annotations: map[string]string{
+						templates.OpenshiftDocURL:                      "test",
+						templates.OpenshiftProviderDisplayName:         "test",
+						templates.OpenshiftSupportURL:                  "test",
+						templates.KubevirtDefaultOSVariant:             "test",
+						templates.TemplateKubevirtProvider:             "test",
+						templates.TemplateKubevirtProviderSupportLevel: "test",
+						templates.TemplateKubevirtProviderURL:          "test",
+						templates.OperatorSDKPrimaryResource:           "test",
+						templates.OperatorSDKPrimaryResourceType:       "test",
+						templates.AppKubernetesComponent:               "test",
+						templates.AppKubernetesManagedBy:               "test",
+						templates.AppKubernetesName:                    "test",
+						templates.AppKubernetesPartOf:                  "test",
+						templates.AppKubernetesVersion:                 "test",
+						templates.TemplateVersionLabel:                 "test",
+						templates.TemplateTypeLabel:                    "test",
+						templates.TemplateOsLabelPrefix:                "test",
+						templates.TemplateFlavorLabelPrefix:            "test",
+						templates.TemplateWorkloadLabelPrefix:          "test",
+						templates.TemplateDeprecatedAnnotation:         "test",
+						"someOtherLabel":                               "test",
+					},
+				},
+			}
+			updatedTemplate := tProvider.UpdateTemplateMetaObject(t)
+			Expect(len(t.GetLabels())).To(Equal(1))
+			Expect(len(t.GetAnnotations())).To(Equal(1))
+
+			for key, val := range t.GetLabels() {
+				if key == "someOtherLabel" {
+					Expect(updatedTemplate.Labels[key]).To(Equal(val))
+				} else {
+					Expect(updatedTemplate.Labels[key]).To(Equal(""))
+				}
+			}
+			for key, val := range t.GetAnnotations() {
+				if key == "someOtherLabel" {
+					Expect(updatedTemplate.Labels[key]).To(Equal(val))
+				} else {
+					Expect(updatedTemplate.Labels[key]).To(Equal(""))
+				}
+			}
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
remove all common-template labels / annotations in copy task
If these annotations / labels would stay in template, ssp operator would
reconcile newly copied template and that can lead to unpredicted
results.

Signed-off-by: Karel Šimon <ksimon@redhat.com>


**Release note**:
```
Copy template task removes all common templates related labels / annotations

```
