### PR TITLE
modify-vm-template: Add deleteTemplate parameter

### DIFF
--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1016,6 +1016,7 @@ metadata:
     memory.params.task.kubevirt.io/type: memory
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
     deleteTemplateParameters.params.task.kubevirt.io/type: boolean
+    deleteTemplate.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -1093,6 +1094,10 @@ spec:
       description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
+    - name: deleteTemplate
+      description: Set to `true` or `false` if task should delete the specified template. If set to 'true' the template will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -1143,6 +1148,8 @@ spec:
           value: $(params.deleteVolumes)
         - name: DELETE_TEMPLATE_PARAMETERS
           value: $(params.deleteTemplateParameters)
+        - name: DELETE_TEMPLATE
+          value: $(params.deleteTemplate)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1154,6 +1161,7 @@ rules:
       - get
       - list
       - patch
+      - delete
     apiGroups:
       - template.openshift.io
     resources:

--- a/modules/modify-vm-template/pkg/utils/parse/clioptions.go
+++ b/modules/modify-vm-template/pkg/utils/parse/clioptions.go
@@ -42,6 +42,7 @@ type CLIOptions struct {
 	DeleteVolumes            bool `arg:"--delete-volumes,env:DELETE_VOLUMES" help:"Delete all VM volumes"`
 	DeleteDisks              bool `arg:"--delete-disks,env:DELETE_DISKS" help:"Delete all VM disks"`
 	DeleteTemplateParameters bool `arg:"--delete-template-parameters,env:DELETE_TEMPLATE_PARAMETERS" help:"Delete datavolume template from template. It deletes associated volumes and disks from VM definition"`
+	DeleteTemplate           bool `arg:"--delete-template,env:DELETE_TEMPLATE" help:"Delete the template instead of modifying it. All other options are ignored when this is set."`
 
 	Debug bool `arg:"--debug" help:"Sets DEBUG log level"`
 
@@ -86,6 +87,10 @@ func (c *CLIOptions) GetDeleteVolumes() bool {
 
 func (c *CLIOptions) GetDeleteTemplateParameters() bool {
 	return c.DeleteTemplateParameters
+}
+
+func (c *CLIOptions) GetDeleteTemplate() bool {
+	return c.DeleteTemplate
 }
 
 func (c *CLIOptions) GetCPUThreads() uint32 {

--- a/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
+++ b/modules/modify-vm-template/pkg/utils/parse/clioptions_test.go
@@ -103,6 +103,7 @@ var _ = Describe("CLIOptions", func() {
 				DeleteVolumes:            true,
 				DeleteDisks:              true,
 				DeleteTemplateParameters: true,
+				DeleteTemplate:           true,
 				DeleteDatavolumeTemplate: true,
 				DatavolumeTemplates:      dataVolumeArray,
 				TemplateParameters:       templateParametersArray,
@@ -160,6 +161,7 @@ var _ = Describe("CLIOptions", func() {
 			DeleteDisks:              true,
 			DeleteVolumes:            true,
 			DeleteTemplateParameters: true,
+			DeleteTemplate:           true,
 		}
 		DescribeTable("CLI options should return correct map of annotations / labels", func(obj *parse.CLIOptions, fnToCall func() map[string]string, result map[string]string) {
 			Expect(obj.Init()).To(Succeed(), "should succeeded")
@@ -206,6 +208,7 @@ var _ = Describe("CLIOptions", func() {
 			Entry("GetDeleteDisks should return correct value", cli, cli.GetDeleteDisks, true),
 			Entry("GetDeleteVolumes should return correct value", cli, cli.GetDeleteVolumes, true),
 			Entry("GetDeleteTemplateParameters should return correct value", cli, cli.GetDeleteTemplateParameters, true),
+			Entry("GetDeleteTemplate should return correct value", cli, cli.GetDeleteTemplate, true),
 		)
 	})
 })

--- a/modules/tests/test/constants/modify-vm-template.go
+++ b/modules/tests/test/constants/modify-vm-template.go
@@ -29,6 +29,7 @@ const (
 	DeleteDisksOptionName              = "deleteDisks"
 	DeleteVolumesOptionName            = "deleteVolumes"
 	DeleteTemplateParametersOptionName = "deleteTemplateParameters"
+	DeleteTemplateOptionName           = "deleteTemplate"
 	TemplateParametersOptionName       = "templateParameters"
 
 	CPUSocketsTopologyNumber    uint32 = 1

--- a/modules/tests/test/testconfigs/modify-vm-template-test-config.go
+++ b/modules/tests/test/testconfigs/modify-vm-template-test-config.go
@@ -32,6 +32,7 @@ type ModifyTemplateTaskData struct {
 	DeleteDisks              bool
 	DeleteVolumes            bool
 	DeleteTemplateParameters bool
+	DeleteTemplate           bool
 }
 
 type ModifyTemplateTestConfig struct {
@@ -115,6 +116,12 @@ func (m *ModifyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			Value: v1beta1.ArrayOrString{
 				Type:      v1beta1.ParamTypeString,
 				StringVal: strconv.FormatBool(m.TaskData.DeleteTemplateParameters),
+			},
+		}, {
+			Name: DeleteTemplateOptionName,
+			Value: v1beta1.ArrayOrString{
+				Type:      v1beta1.ParamTypeString,
+				StringVal: strconv.FormatBool(m.TaskData.DeleteTemplate),
 			},
 		},
 	}

--- a/tasks/modify-vm-template/README.md
+++ b/tasks/modify-vm-template/README.md
@@ -28,6 +28,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **deleteVolumes**: Set to `true` or `false` if task should delete VM volumes. New volumes (from volumes parameter) are applied, after old volumes are deleted.
 - **templateParameters**: Definition of template parameters. Eg [{`description`: `VM name`, `name`: `NAME`}]
 - **deleteTemplateParameters**: Set to `true` or `false` if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
+- **deleteTemplate**: Set to `true` or `false` if task should delete the specified template. If set to 'true' the template will be deleted and all other parameters are ignored.
 
 ### Results
 

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -13,6 +13,7 @@ metadata:
     memory.params.task.kubevirt.io/type: memory
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
     deleteTemplateParameters.params.task.kubevirt.io/type: boolean
+    deleteTemplate.params.task.kubevirt.io/type: boolean
   labels:
     task.kubevirt.io/type: modify-vm-template
     task.kubevirt.io/category: modify-vm-template
@@ -90,6 +91,10 @@ spec:
       description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
+    - name: deleteTemplate
+      description: Set to `true` or `false` if task should delete the specified template. If set to 'true' the template will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -140,6 +145,8 @@ spec:
           value: $(params.deleteVolumes)
         - name: DELETE_TEMPLATE_PARAMETERS
           value: $(params.deleteTemplateParameters)
+        - name: DELETE_TEMPLATE
+          value: $(params.deleteTemplate)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -151,6 +158,7 @@ rules:
       - get
       - list
       - patch
+      - delete
     apiGroups:
       - template.openshift.io
     resources:

--- a/templates/modify-vm-template/manifests/modify-vm-template-role.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template-role.yaml
@@ -8,6 +8,7 @@ rules:
       - get
       - list
       - patch
+      - delete
     apiGroups:
       - template.openshift.io
     resources:

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -13,6 +13,7 @@ metadata:
     memory.params.task.kubevirt.io/type: {{ task_param_types.memory }}
     deleteDatavolumeTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
     deleteTemplateParameters.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    deleteTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
     task.kubevirt.io/type: {{ task_name }}
     task.kubevirt.io/category: {{ task_category }}
@@ -90,6 +91,10 @@ spec:
       description: Set to "true" or "false" if task should delete template parameters. New parameters (from templateParameters parameter) are applied, after old parameters are deleted.
       default: 'false'
       type: string
+    - name: deleteTemplate
+      description: Set to `true` or `false` if task should delete the specified template. If set to 'true' the template will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
 
   results:
     - name: name
@@ -140,3 +145,5 @@ spec:
           value: $(params.deleteVolumes)
         - name: DELETE_TEMPLATE_PARAMETERS
           value: $(params.deleteTemplateParameters)
+        - name: DELETE_TEMPLATE
+          value: $(params.deleteTemplate)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this parameter the modify-vm-template task can be instructed to
delete the specified template instead of modifying it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
modify-vm-template: Add deleteTemplate parameter
```
