### PR TITLE
[release-v0.9.0] enable creating datasources in create-datavolume-task

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -167,33 +167,39 @@ spec:
 
         set -e
 
-        TMP_DV_YAML_FILENAME="/tmp/datavolume.yaml"
-        TMP_DV_RESULTS_FILENAME="/tmp/dv_results"
+        TMP_OBJ_YAML_FILENAME="/tmp/datavolume.yaml"
+        TMP_OBJ_RESULTS_FILENAME="/tmp/dv_results"
 
-        echo "$(inputs.params.manifest)" > "$TMP_DV_YAML_FILENAME"
+        echo "$(inputs.params.manifest)" > "$TMP_OBJ_YAML_FILENAME"
 
-        if ! grep -q "kind: DataVolume$" "$TMP_DV_YAML_FILENAME"; then
-            1>&2 echo "manifest does not contain DataVolume kind!"
+        if [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataVolume"* ]] && [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataSource"* ]]; then
+            1>&2 echo "manifest does not contain DataVolume or DataSource kind!"
             exit 1
         fi
 
-        oc create -f "$TMP_DV_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_DV_RESULTS_FILENAME"
+        oc create -f "$TMP_OBJ_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_OBJ_RESULTS_FILENAME"
 
-        sed -i 's/ /\n/g' "$TMP_DV_RESULTS_FILENAME"
-        readarray -t DV_OUTPUT_ARRAY < "$TMP_DV_RESULTS_FILENAME"
+        sed -i 's/ /\n/g' "$TMP_OBJ_RESULTS_FILENAME"
+        readarray -t OBJ_OUTPUT_ARRAY < "$TMP_OBJ_RESULTS_FILENAME"
 
-        DV_NAME="${DV_OUTPUT_ARRAY[0]}"
-        DV_NAMESPACE="${DV_OUTPUT_ARRAY[1]}"
+        OBJ_NAME="${OBJ_OUTPUT_ARRAY[0]}"
+        OBJ_NAMESPACE="${OBJ_OUTPUT_ARRAY[1]}"
 
-        echo -n "$DV_NAME" > /tekton/results/name
-        echo -n "$DV_NAMESPACE" > /tekton/results/namespace
+        echo -n "$OBJ_NAME" > /tekton/results/name
+        echo -n "$OBJ_NAMESPACE" > /tekton/results/namespace
 
-        echo "Created $DV_NAME Datavolume in $DV_NAMESPACE namespace."
+        echo "Created $OBJ_NAME Datavolume in $OBJ_NAMESPACE namespace."
 
-        if [ "$(inputs.params.waitForSuccess)" == true ]; then
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataVolume"* ]]; then
             echo "Waiting for Ready condition."
             # TODO: detect failed imports and don't wait until wait timeouts
-            oc wait "datavolumes.cdi.kubevirt.io/$DV_NAME" --namespace="$DV_NAMESPACE" --for="condition=Ready" --timeout=720h
+            oc wait "datavolumes.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
+        fi
+
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataSource"* ]]; then
+            echo "Waiting for Ready condition."
+            # TODO: detect failed imports and don't wait until wait timeouts
+            oc wait "datasources.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
         fi
 
 ---
@@ -211,6 +217,15 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datasources
   - verbs:
       - create
     apiGroups:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -264,33 +264,39 @@ spec:
 
         set -e
 
-        TMP_DV_YAML_FILENAME="/tmp/datavolume.yaml"
-        TMP_DV_RESULTS_FILENAME="/tmp/dv_results"
+        TMP_OBJ_YAML_FILENAME="/tmp/datavolume.yaml"
+        TMP_OBJ_RESULTS_FILENAME="/tmp/dv_results"
 
-        echo "$(inputs.params.manifest)" > "$TMP_DV_YAML_FILENAME"
+        echo "$(inputs.params.manifest)" > "$TMP_OBJ_YAML_FILENAME"
 
-        if ! grep -q "kind: DataVolume$" "$TMP_DV_YAML_FILENAME"; then
-            1>&2 echo "manifest does not contain DataVolume kind!"
+        if [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataVolume"* ]] && [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataSource"* ]]; then
+            1>&2 echo "manifest does not contain DataVolume or DataSource kind!"
             exit 1
         fi
 
-        oc create -f "$TMP_DV_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_DV_RESULTS_FILENAME"
+        oc create -f "$TMP_OBJ_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_OBJ_RESULTS_FILENAME"
 
-        sed -i 's/ /\n/g' "$TMP_DV_RESULTS_FILENAME"
-        readarray -t DV_OUTPUT_ARRAY < "$TMP_DV_RESULTS_FILENAME"
+        sed -i 's/ /\n/g' "$TMP_OBJ_RESULTS_FILENAME"
+        readarray -t OBJ_OUTPUT_ARRAY < "$TMP_OBJ_RESULTS_FILENAME"
 
-        DV_NAME="${DV_OUTPUT_ARRAY[0]}"
-        DV_NAMESPACE="${DV_OUTPUT_ARRAY[1]}"
+        OBJ_NAME="${OBJ_OUTPUT_ARRAY[0]}"
+        OBJ_NAMESPACE="${OBJ_OUTPUT_ARRAY[1]}"
 
-        echo -n "$DV_NAME" > /tekton/results/name
-        echo -n "$DV_NAMESPACE" > /tekton/results/namespace
+        echo -n "$OBJ_NAME" > /tekton/results/name
+        echo -n "$OBJ_NAMESPACE" > /tekton/results/namespace
 
-        echo "Created $DV_NAME Datavolume in $DV_NAMESPACE namespace."
+        echo "Created $OBJ_NAME Datavolume in $OBJ_NAMESPACE namespace."
 
-        if [ "$(inputs.params.waitForSuccess)" == true ]; then
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataVolume"* ]]; then
             echo "Waiting for Ready condition."
             # TODO: detect failed imports and don't wait until wait timeouts
-            oc wait "datavolumes.cdi.kubevirt.io/$DV_NAME" --namespace="$DV_NAMESPACE" --for="condition=Ready" --timeout=720h
+            oc wait "datavolumes.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
+        fi
+
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataSource"* ]]; then
+            echo "Waiting for Ready condition."
+            # TODO: detect failed imports and don't wait until wait timeouts
+            oc wait "datasources.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
         fi
 
 ---
@@ -308,6 +314,15 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datasources
   - verbs:
       - create
     apiGroups:

--- a/modules/tests/test/create_datasource_test.go
+++ b/modules/tests/test/create_datasource_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"context"
+
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume"
+	. "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/ds"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/dv"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/framework"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/runner"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/testconfigs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Create DataSource", func() {
+	f := framework.NewFramework()
+	DescribeTable("DataSource is created successfully", func(config *testconfigs.CreateDVTestConfig) {
+		f.TestSetup(config)
+		if config.DataSource.TestDV != nil {
+			newDataVolume, err := f.CdiClient.DataVolumes(config.DataSource.TestDV.Namespace).Create(context.TODO(), config.DataSource.TestDV, v1.CreateOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			f.ManageDataVolumes(newDataVolume)
+
+			err = dv.WaitForSuccessfulDataVolume(f.CdiClient, newDataVolume.Namespace, newDataVolume.Name, config.GetWaitForDVTimeout())
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		datasource := config.DataSource.DataSource
+		f.ManageDataSources(datasource)
+
+		runner.NewTaskRunRunner(f, config.GetTaskRun()).
+			CreateTaskRun().
+			ExpectSuccess().
+			ExpectLogs(config.GetAllExpectedLogs()...).
+			ExpectResults(map[string]string{
+				CreateDataVolumeFromManifestResults.Name:      datasource.Name,
+				CreateDataVolumeFromManifestResults.Namespace: datasource.Namespace,
+			})
+
+		err := ds.WaitForSuccessfulDataSource(f.CdiClient, datasource.Namespace, datasource.Name, config.GetWaitForDSTimeout())
+		Expect(err).ShouldNot(HaveOccurred())
+	},
+		Entry("pointing to pvc with wait", &testconfigs.CreateDVTestConfig{
+			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
+				ServiceAccount: CreateDataVolumeFromManifestServiceAccountName,
+				Timeout:        Timeouts.SmallDVCreation,
+				ExpectedLogs:   "Created",
+			},
+			DataSource: testconfigs.CreateDSTaskData{
+				DataSource:     ds.NewDataSource("test-ds"),
+				WaitForSuccess: true,
+				Namespace:      DeployTargetNS,
+				TestDV:         datavolume.NewBlankDataVolume("test-ds").Build(),
+			},
+		}),
+		Entry("pointing to pvc without wait", &testconfigs.CreateDVTestConfig{
+			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
+				ServiceAccount: CreateDataVolumeFromManifestServiceAccountName,
+				Timeout:        Timeouts.SmallDVCreation,
+				ExpectedLogs:   "Created",
+			},
+			DataSource: testconfigs.CreateDSTaskData{
+				DataSource:     ds.NewDataSource("test-ds"),
+				WaitForSuccess: false,
+				Namespace:      DeployTargetNS,
+				TestDV:         datavolume.NewBlankDataVolume("test-ds").Build(),
+			},
+		}),
+	)
+})

--- a/modules/tests/test/ds/conditions.go
+++ b/modules/tests/test/ds/conditions.go
@@ -1,0 +1,14 @@
+package ds
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+func GetConditionMap(ds *v1beta1.DataSource) map[v1beta1.DataSourceConditionType]v1.ConditionStatus {
+	result := make(map[v1beta1.DataSourceConditionType]v1.ConditionStatus)
+	for _, cond := range ds.Status.Conditions {
+		result[cond.Type] = cond.Status
+	}
+	return result
+}

--- a/modules/tests/test/ds/datasource.go
+++ b/modules/tests/test/ds/datasource.go
@@ -1,0 +1,32 @@
+package ds
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta12 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+)
+
+const (
+	dataSourceKind       = "DataSource"
+	dataSourceApiVersion = "cdi.kubevirt.io/v1beta1"
+)
+
+func NewDataSource(name string) *v1beta12.DataSource {
+	dataSource := &v1beta12.DataSource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: dataSourceApiVersion,
+			Kind:       dataSourceKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1beta12.DataSourceSpec{
+			Source: v1beta12.DataSourceSource{
+				PVC: &v1beta12.DataVolumeSourcePVC{
+					Name: name,
+				},
+			},
+		},
+	}
+
+	return dataSource
+}

--- a/modules/tests/test/ds/operations.go
+++ b/modules/tests/test/ds/operations.go
@@ -1,0 +1,40 @@
+package ds
+
+import (
+	"context"
+	"time"
+
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	cdiv1beta12 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	cdicliv1beta1 "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/typed/core/v1beta1"
+)
+
+func WaitForSuccessfulDataSource(cdiClientSet cdicliv1beta1.CdiV1beta1Interface, namespace, name string, timeout time.Duration) error {
+	return wait.PollImmediate(constants.PollInterval, timeout, func() (bool, error) {
+		dataSource, err := cdiClientSet.DataSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return isDataSourceImportStatusSuccessful(dataSource), nil
+	})
+}
+
+func IsDataSourceImportSuccessful(cdiClientSet cdicliv1beta1.CdiV1beta1Interface, namespace string, name string) bool {
+	dataSource, err := cdiClientSet.DataSources(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	return isDataSourceImportStatusSuccessful(dataSource)
+}
+
+func HasDataSourceFailedToImport(dataSource *cdiv1beta12.DataSource) bool {
+	conditions := GetConditionMap(dataSource)
+	return conditions[cdiv1beta12.DataSourceReady] == v1.ConditionFalse
+}
+
+func isDataSourceImportStatusSuccessful(dataSource *cdiv1beta12.DataSource) bool {
+	return GetConditionMap(dataSource)[cdiv1beta12.DataSourceReady] == v1.ConditionTrue
+}

--- a/tasks/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest.yaml
+++ b/tasks/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest.yaml
@@ -37,33 +37,39 @@ spec:
 
         set -e
 
-        TMP_DV_YAML_FILENAME="/tmp/datavolume.yaml"
-        TMP_DV_RESULTS_FILENAME="/tmp/dv_results"
+        TMP_OBJ_YAML_FILENAME="/tmp/datavolume.yaml"
+        TMP_OBJ_RESULTS_FILENAME="/tmp/dv_results"
 
-        echo "$(inputs.params.manifest)" > "$TMP_DV_YAML_FILENAME"
+        echo "$(inputs.params.manifest)" > "$TMP_OBJ_YAML_FILENAME"
 
-        if ! grep -q "kind: DataVolume$" "$TMP_DV_YAML_FILENAME"; then
-            1>&2 echo "manifest does not contain DataVolume kind!"
+        if [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataVolume"* ]] && [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataSource"* ]]; then
+            1>&2 echo "manifest does not contain DataVolume or DataSource kind!"
             exit 1
         fi
 
-        oc create -f "$TMP_DV_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_DV_RESULTS_FILENAME"
+        oc create -f "$TMP_OBJ_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_OBJ_RESULTS_FILENAME"
 
-        sed -i 's/ /\n/g' "$TMP_DV_RESULTS_FILENAME"
-        readarray -t DV_OUTPUT_ARRAY < "$TMP_DV_RESULTS_FILENAME"
+        sed -i 's/ /\n/g' "$TMP_OBJ_RESULTS_FILENAME"
+        readarray -t OBJ_OUTPUT_ARRAY < "$TMP_OBJ_RESULTS_FILENAME"
 
-        DV_NAME="${DV_OUTPUT_ARRAY[0]}"
-        DV_NAMESPACE="${DV_OUTPUT_ARRAY[1]}"
+        OBJ_NAME="${OBJ_OUTPUT_ARRAY[0]}"
+        OBJ_NAMESPACE="${OBJ_OUTPUT_ARRAY[1]}"
 
-        echo -n "$DV_NAME" > /tekton/results/name
-        echo -n "$DV_NAMESPACE" > /tekton/results/namespace
+        echo -n "$OBJ_NAME" > /tekton/results/name
+        echo -n "$OBJ_NAMESPACE" > /tekton/results/namespace
 
-        echo "Created $DV_NAME Datavolume in $DV_NAMESPACE namespace."
+        echo "Created $OBJ_NAME Datavolume in $OBJ_NAMESPACE namespace."
 
-        if [ "$(inputs.params.waitForSuccess)" == true ]; then
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataVolume"* ]]; then
             echo "Waiting for Ready condition."
             # TODO: detect failed imports and don't wait until wait timeouts
-            oc wait "datavolumes.cdi.kubevirt.io/$DV_NAME" --namespace="$DV_NAMESPACE" --for="condition=Ready" --timeout=720h
+            oc wait "datavolumes.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
+        fi
+
+        if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataSource"* ]]; then
+            echo "Waiting for Ready condition."
+            # TODO: detect failed imports and don't wait until wait timeouts
+            oc wait "datasources.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
         fi
 
 ---
@@ -81,6 +87,15 @@ rules:
       - cdi.kubevirt.io
     resources:
       - datavolumes
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datasources
   - verbs:
       - create
     apiGroups:

--- a/templates/create-datavolume-from-manifest/create-datavolume-script.sh
+++ b/templates/create-datavolume-from-manifest/create-datavolume-script.sh
@@ -2,31 +2,37 @@
 
 set -e
 
-TMP_DV_YAML_FILENAME="/tmp/datavolume.yaml"
-TMP_DV_RESULTS_FILENAME="/tmp/dv_results"
+TMP_OBJ_YAML_FILENAME="/tmp/datavolume.yaml"
+TMP_OBJ_RESULTS_FILENAME="/tmp/dv_results"
 
-echo "$(inputs.params.manifest)" > "$TMP_DV_YAML_FILENAME"
+echo "$(inputs.params.manifest)" > "$TMP_OBJ_YAML_FILENAME"
 
-if ! grep -q "kind: DataVolume$" "$TMP_DV_YAML_FILENAME"; then
-    1>&2 echo "manifest does not contain DataVolume kind!"
+if [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataVolume"* ]] && [[ ! "$(cat $TMP_OBJ_YAML_FILENAME)" == *"kind: DataSource"* ]]; then
+    1>&2 echo "manifest does not contain DataVolume or DataSource kind!"
     exit 1
 fi
 
-oc create -f "$TMP_DV_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_DV_RESULTS_FILENAME"
+oc create -f "$TMP_OBJ_YAML_FILENAME" -o  jsonpath='{.metadata.name} {.metadata.namespace}' > "$TMP_OBJ_RESULTS_FILENAME"
 
-sed -i 's/ /\n/g' "$TMP_DV_RESULTS_FILENAME"
-readarray -t DV_OUTPUT_ARRAY < "$TMP_DV_RESULTS_FILENAME"
+sed -i 's/ /\n/g' "$TMP_OBJ_RESULTS_FILENAME"
+readarray -t OBJ_OUTPUT_ARRAY < "$TMP_OBJ_RESULTS_FILENAME"
 
-DV_NAME="${DV_OUTPUT_ARRAY[0]}"
-DV_NAMESPACE="${DV_OUTPUT_ARRAY[1]}"
+OBJ_NAME="${OBJ_OUTPUT_ARRAY[0]}"
+OBJ_NAMESPACE="${OBJ_OUTPUT_ARRAY[1]}"
 
-echo -n "$DV_NAME" > /tekton/results/name
-echo -n "$DV_NAMESPACE" > /tekton/results/namespace
+echo -n "$OBJ_NAME" > /tekton/results/name
+echo -n "$OBJ_NAMESPACE" > /tekton/results/namespace
 
-echo "Created $DV_NAME Datavolume in $DV_NAMESPACE namespace."
+echo "Created $OBJ_NAME Datavolume in $OBJ_NAMESPACE namespace."
 
-if [ "$(inputs.params.waitForSuccess)" == true ]; then
+if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataVolume"* ]]; then
     echo "Waiting for Ready condition."
     # TODO: detect failed imports and don't wait until wait timeouts
-    oc wait "datavolumes.cdi.kubevirt.io/$DV_NAME" --namespace="$DV_NAMESPACE" --for="condition=Ready" --timeout=720h
+    oc wait "datavolumes.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
+fi
+
+if [[ "$(inputs.params.waitForSuccess)" == true ]] && [[ "$TMP_OBJ_YAML_FILENAME" == *"kind: DataSource"* ]]; then
+    echo "Waiting for Ready condition."
+    # TODO: detect failed imports and don't wait until wait timeouts
+    oc wait "datasources.cdi.kubevirt.io/$OBJ_NAME" --namespace="$OBJ_NAMESPACE" --for="condition=Ready" --timeout=720h
 fi

--- a/templates/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest-role.yaml
+++ b/templates/create-datavolume-from-manifest/manifests/create-datavolume-from-manifest-role.yaml
@@ -14,6 +14,15 @@ rules:
     resources:
       - datavolumes
   - verbs:
+      - get
+      - list
+      - watch
+      - create
+    apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datasources
+  - verbs:
       - create
     apiGroups:
       - ""


### PR DESCRIPTION
**What this PR does / why we need it**:
enhance create-datavolume-task with ability to create datasources
    
the task will be able to create datasource and wait for it to finish.
The task was not renamed, because this is mostly mean as a fix for
release-v0.3 branch. New version of create-datavolume task will be
rewritten to go language and will have support for both datavolumes
and datasources

**Release note**:
```release-note
create-datavolume task can create datasources objects
```
