### PR TITLE
Bump create-data-object golang version to 1.17 temporarily

### DIFF
--- a/modules/create-data-object/build/create-data-object/Dockerfile
+++ b/modules/create-data-object/build/create-data-object/Dockerfile
@@ -1,4 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
-RUN microdnf install -y golang-1.16.* && microdnf clean all
+RUN microdnf install -y golang-1.17.* && microdnf clean all
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump create-data-object golang version to 1.17 temporarily

It is needed so the task can be onboarded to the CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
