### PR TITLE
Add script to obtain Windows 10 ISO download URL in an automated way

### DIFF
--- a/examples/pipelines/windows10-installer/README.md
+++ b/examples/pipelines/windows10-installer/README.md
@@ -35,6 +35,23 @@ This version is using templates, which are not available on Kubernetes.
 WIN_URL="https://software.download.prss.microsoft.com/db/Win10_21H2_English_x64.iso..."
 ```
 
+#### Obtaining a download URL in an automated way
+
+The script [`getisourl.py`](getisourl.py) can be used to automatically obtain a Windows 10 ISO download URL.
+
+The prerequisites are:
+
+- python3-selenium
+- chromedriver
+- chromium
+
+Run it as follows to initialize a WIN_URL variable.
+
+```bash
+# Real URL can look differently
+WIN_URL=$(./getisourl.py)
+```
+
 ### Prepare autounattend.xml ConfigMap
 
 1. Supply, generate or use the default autounattend.xml.

--- a/examples/pipelines/windows10-installer/getisourl.py
+++ b/examples/pipelines/windows10-installer/getisourl.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
+
+options = Options()
+options.headless = True
+
+driver = webdriver.Chrome(options=options)
+driver.implicitly_wait(10)
+
+try:
+    driver.get("https://www.microsoft.com/en-us/software-download/windows10ISO")
+
+    select_object = Select(driver.find_element(By.ID, "product-edition"))
+    select_object.select_by_index(1)
+
+    button_element = driver.find_element(By.ID, "submit-product-edition")
+    button_element.click()
+
+    select_object = Select(driver.find_element(By.ID, "product-languages"))
+    select_object.select_by_visible_text("English (United States)")
+
+    button_element = driver.find_element(By.ID, "submit-sku")
+    button_element.click()
+
+    download_link = driver.find_element(By.LINK_TEXT, "64-bit Download")
+    print(download_link.get_attribute("href"))
+except:
+    pass
+
+driver.close()


### PR DESCRIPTION
**What this PR does / why we need it**:

The getisourl.py script was added. It allows to obtain WIndows 10 ISO
download URLs in an automated way.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add script to obtain Windows 10 ISO download URL in an automated way
```
