### PR TITLE
wait for tekton pipelines webhook

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -49,6 +49,16 @@ timeout 10m bash <<- EOF
   done
 EOF
 
+# wait until tekton pipelines webhook is created
+timeout 10m bash <<- EOF
+  until kubectl get deployment tekton-pipelines-webhook -n openshift-pipelines; do
+    sleep 5
+  done
+EOF
+
+# wait until tekton pipelines webhook is online
+kubectl wait -n openshift-pipelines deployment tekton-pipelines-webhook --for condition=Available --timeout 10m
+
 # Wait for kubevirt to be available
 kubectl rollout status -n cdi deployment/cdi-operator --timeout 10m
 kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 10m


### PR DESCRIPTION
**What this PR does / why we need it**:
wait for tekton pipelines webhook
e2e tests are failing, because tekton pipelines webhook is not online.
This change adds wait command which waits until webhook become available

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
