### PR TITLE
add delete option to create-data-object task

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -148,6 +148,7 @@ spec:
     - name: manifest
       description: YAML manifest of a data object to be created.
       type: string
+      default: ''
     - name: namespace
       description: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
       default: ""
@@ -160,6 +161,18 @@ spec:
       description: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: deleteObject
+      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
+    - name: deleteObjectKind
+      description: Kind of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
+    - name: deleteObjectName
+      description: Name of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
   results:
     - name: name
       description: The name of the data object that was created.
@@ -181,6 +194,12 @@ spec:
           value: $(params.waitForSuccess)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: DELETE_OBJECT
+          value: $(params.deleteObject)
+        - name: DELETE_OBJECT_KIND
+          value: $(params.deleteObjectKind)
+        - name: DELETE_OBJECT_NAME
+          value: $(params.deleteObjectName)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -245,6 +245,7 @@ spec:
     - name: manifest
       description: YAML manifest of a data object to be created.
       type: string
+      default: ''
     - name: namespace
       description: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
       default: ""
@@ -257,6 +258,18 @@ spec:
       description: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: deleteObject
+      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
+    - name: deleteObjectKind
+      description: Kind of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
+    - name: deleteObjectName
+      description: Name of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
   results:
     - name: name
       description: The name of the data object that was created.
@@ -278,6 +291,12 @@ spec:
           value: $(params.waitForSuccess)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: DELETE_OBJECT
+          value: $(params.deleteObject)
+        - name: DELETE_OBJECT_KIND
+          value: $(params.deleteObjectKind)
+        - name: DELETE_OBJECT_NAME
+          value: $(params.deleteObjectName)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/create-data-object/cmd/create-data-object/main.go
+++ b/modules/create-data-object/cmd/create-data-object/main.go
@@ -36,6 +36,15 @@ func main() {
 		exit.ExitOrDieFromError(DataObjectCreatorErrorCode, err)
 	}
 
+	if cliOptions.GetDeleteObject() {
+		err := dataObjectCreator.DeleteDataObject()
+		if err != nil {
+			exit.ExitOrDieFromError(DeleteObjectExitCode, err)
+		}
+		log.Logger().Debug("Object was deleted")
+		return
+	}
+
 	newDataObject, err := dataObjectCreator.CreateDataObject()
 	if err != nil {
 		exit.ExitOrDieFromError(CreateDataObjectErrorCode, err,

--- a/modules/create-data-object/pkg/constants/constants.go
+++ b/modules/create-data-object/pkg/constants/constants.go
@@ -8,6 +8,7 @@ const (
 	DataObjectCreatorErrorCode = 1
 	CreateDataObjectErrorCode  = 2
 	WriteResultsExitCode       = 3
+	DeleteObjectExitCode       = 4
 )
 
 // apiVersion and kinds

--- a/modules/tests/test/constants/create-data-object.go
+++ b/modules/tests/test/constants/create-data-object.go
@@ -10,15 +10,23 @@ const (
 )
 
 type createDataObjectParams struct {
-	Manifest       string
-	WaitForSuccess string
-	AllowReplace   string
+	Manifest            string
+	WaitForSuccess      string
+	AllowReplace        string
+	DeleteObject        string
+	DeleteObjectName    string
+	DeleteObjectKind    string
+	DataObjectNamespace string
 }
 
 var CreateDataObjectParams = createDataObjectParams{
-	Manifest:       "manifest",
-	WaitForSuccess: "waitForSuccess",
-	AllowReplace:   "allowReplace",
+	Manifest:            "manifest",
+	WaitForSuccess:      "waitForSuccess",
+	AllowReplace:        "allowReplace",
+	DeleteObject:        "deleteObject",
+	DeleteObjectName:    "deleteObjectName",
+	DeleteObjectKind:    "deleteObjectKind",
+	DataObjectNamespace: "namespace",
 }
 
 type createDataObjectResults struct {

--- a/modules/tests/test/framework/framework.go
+++ b/modules/tests/test/framework/framework.go
@@ -130,7 +130,6 @@ func (f *Framework) AfterEach() {
 			defer f.TknClient.PipelineRuns(pipelineRun.Namespace).Delete(context.TODO(), pipelineRun.Name, metav1.DeleteOptions{})
 		}
 	}
-
 	for _, pipeline := range f.managedResources.pipelines {
 		defer f.TknClient.Pipelines(pipeline.Namespace).Delete(context.TODO(), pipeline.Name, metav1.DeleteOptions{})
 	}

--- a/modules/tests/test/pipelines_test.go
+++ b/modules/tests/test/pipelines_test.go
@@ -1,1 +1,252 @@
 package test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/framework"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/runner"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/testconfigs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+var _ = Describe("Pipelines tests", func() {
+	f := framework.NewFramework()
+	It("DV is created, disk-virt-sysprep, create dv, delete dvs", func() {
+		config := &testconfigs.PipelineTestConfig{
+			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
+				ServiceAccount: CreateDataObjectServiceAccountName,
+				Timeout:        Timeouts.PipelineRunExtraWaitDelay,
+			},
+			Pipeline: &v1beta1.Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pipeline-dvs",
+				},
+				Spec: v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{
+						{
+							Name: "create-dv",
+							TaskRef: &v1beta1.TaskRef{
+								Kind: v1beta1.ClusterTaskKind,
+								Name: "create-data-object",
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "waitForSuccess",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "true",
+									},
+								}, {
+									Name: "manifest",
+									Value: v1beta1.ArrayOrString{
+										Type: v1beta1.ParamTypeString,
+										StringVal: `
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: test-dv
+  annotations:
+  cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+spec:
+  pvc:
+    resources:
+      requests:
+        storage: 13Gi
+    accessModes:
+    - ReadWriteOnce
+  source:
+    registry:
+      url: "docker://quay.io/containerdisks/centos-stream:9"
+											`,
+									},
+								},
+							},
+						}, {
+							Name: "sysprep-dv",
+							TaskRef: &v1beta1.TaskRef{
+								Kind: v1beta1.ClusterTaskKind,
+								Name: "disk-virt-sysprep",
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "sysprepCommands",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "run-command echo 'krtek' > new",
+									},
+								}, {
+									Name: "pvc",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(tasks.create-dv.results.name)",
+									},
+								},
+							},
+							RunAfter: []string{"create-dv"},
+						}, {
+							Name: "create-updated-dv",
+							TaskRef: &v1beta1.TaskRef{
+								Kind: v1beta1.ClusterTaskKind,
+								Name: "create-data-object",
+							},
+							Params: []v1beta1.Param{
+								{
+
+									Name: "manifest",
+									Value: v1beta1.ArrayOrString{
+										Type: v1beta1.ParamTypeString,
+										StringVal: `
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: test-dv-updated
+  annotations:
+  cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+spec:
+  pvc:
+    resources:
+      requests:
+        storage: 13Gi
+    accessModes:
+    - ReadWriteOnce
+  source:
+    pvc:
+      name: "$(tasks.create-dv.results.name)"
+      namespace: "$(tasks.create-dv.results.namespace)"
+
+											`,
+									},
+								},
+							},
+							RunAfter: []string{"sysprep-dv"},
+						}, {
+							Name: "delete-updated-dv",
+							TaskRef: &v1beta1.TaskRef{
+								Kind: v1beta1.ClusterTaskKind,
+								Name: "create-data-object",
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "deleteObject",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "true",
+									},
+								}, {
+									Name: "deleteObjectName",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(tasks.create-dv.results.name)",
+									},
+								}, {
+									Name: "deleteObjectKind",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "DataVolume",
+									},
+								},
+							},
+							RunAfter: []string{"create-updated-dv"},
+						}, {
+							Name: "delete-original-dv",
+							TaskRef: &v1beta1.TaskRef{
+								Kind: v1beta1.ClusterTaskKind,
+								Name: "create-data-object",
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "deleteObject",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "true",
+									},
+								}, {
+									Name: "deleteObjectName",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(tasks.create-updated-dv.results.name)",
+									},
+								}, {
+									Name: "deleteObjectKind",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "DataVolume",
+									},
+								},
+							},
+							RunAfter: []string{"create-updated-dv"},
+						},
+					},
+				},
+			},
+			PipelineRunData: testconfigs.PipelineRunData{
+				Name:   "test-dv-hardening",
+				Params: []v1beta1.Param{},
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "test-pipeline-dvs",
+				},
+				TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{
+					{
+						PipelineTaskName:       "create-dv",
+						TaskServiceAccountName: "create-data-object-task",
+					}, {
+						PipelineTaskName:       "create-updated-dv",
+						TaskServiceAccountName: "create-data-object-task",
+					}, {
+						PipelineTaskName:       "delete-updated-dv",
+						TaskServiceAccountName: "create-data-object-task",
+					}, {
+						PipelineTaskName:       "delete-original-dv",
+						TaskServiceAccountName: "create-data-object-task",
+					},
+				},
+			},
+		}
+
+		f.TestSetup(config)
+		pipelineRun := config.GetPipelineRun()
+		_, err := f.TknClient.Pipelines(config.PipelineRun.Namespace).Create(context.TODO(), config.Pipeline, metav1.CreateOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		f.ManagePipelines(config.Pipeline)
+		f.ManagePipelineRuns(config.PipelineRun)
+
+		runner.NewPipelineRunRunner(f, pipelineRun).
+			CreatePipelineRun().
+			ExpectSuccess()
+
+		pr, err := f.TknClient.PipelineRuns(config.PipelineRun.Namespace).Get(context.TODO(), config.PipelineRun.Name, metav1.GetOptions{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		succeededConditionFound := false
+		for _, condition := range pr.Status.Conditions {
+			if condition.Type == apis.ConditionSucceeded && condition.Status == corev1.ConditionTrue {
+				succeededConditionFound = true
+			}
+		}
+		Expect(succeededConditionFound).To(BeTrue(), "pipelineRun should succeed")
+
+		Eventually(func(g Gomega) bool {
+			dataVolumes, err := f.CdiClient.DataVolumes(config.PipelineRun.Namespace).List(context.TODO(), metav1.ListOptions{})
+
+			if err != nil {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			for _, dataVolume := range dataVolumes.Items {
+				//look only for created datavolumes in this pipeline test
+				if dataVolume.Name == "test-dv" || dataVolume.Name == "test-dv-updated" {
+					return false
+				}
+			}
+			return true
+
+		}, Timeouts.TaskRunExtraWaitDelay.Duration, time.Second).Should(BeTrue(), "DataVolumes should be deleted")
+	})
+})

--- a/modules/tests/test/tekton/pipelinerun.go
+++ b/modules/tests/test/tekton/pipelinerun.go
@@ -68,9 +68,8 @@ func WaitForPipelineRunState(clients *clients.Clients, namespace, name string, t
 						Follow: true,
 					})
 					podLogs, err := req.Stream(context.TODO())
-					//when an error occurs, just log the reason and try to get the logs in the next iteration
+					//when an error occurs, just end the function and do nothing, in next iteration the command will run again to get logs
 					if err != nil {
-						fmt.Printf("error while loading pod %s/%s log: %s", namespace, podName, err.Error())
 						return
 					}
 

--- a/modules/tests/test/testconfigs/create-data-object-test-config.go
+++ b/modules/tests/test/testconfigs/create-data-object-test-config.go
@@ -13,12 +13,16 @@ import (
 )
 
 type CreateDataObjectTaskData struct {
-	DataVolume     *cdiv1beta1.DataVolume
-	DataSource     *cdiv1beta1.DataSource
-	RawManifest    string
-	WaitForSuccess bool
-	AllowReplace   bool
-	Namespace      TargetNamespace
+	DataVolume          *cdiv1beta1.DataVolume
+	DataSource          *cdiv1beta1.DataSource
+	RawManifest         string
+	WaitForSuccess      bool
+	AllowReplace        bool
+	DeleteObject        bool
+	DeleteObjectName    string
+	DeleteObjectKind    string
+	Namespace           TargetNamespace
+	dataObjectNamespace string
 }
 
 type CreateDataObjectTestConfig struct {
@@ -55,6 +59,11 @@ func (c *CreateDataObjectTestConfig) Init(options *testoptions.TestOptions) {
 		if options.StorageClass != "" {
 			dv.Spec.PVC.StorageClassName = &options.StorageClass
 		}
+		if c.TaskData.DeleteObjectName != "" {
+			c.TaskData.DeleteObjectName = dv.Name
+		}
+
+		c.TaskData.dataObjectNamespace = dv.Namespace
 	}
 
 	if c.TaskData.DataSource != nil {
@@ -65,6 +74,10 @@ func (c *CreateDataObjectTestConfig) Init(options *testoptions.TestOptions) {
 			ds.Name = E2ETestsRandomName(ds.Name)
 		}
 		ds.Namespace = options.ResolveNamespace(c.TaskData.Namespace, "")
+		if c.TaskData.DeleteObjectName != "" {
+			c.TaskData.DeleteObjectName = ds.Name
+		}
+		c.TaskData.dataObjectNamespace = ds.Namespace
 	}
 
 	if count > 1 {
@@ -125,6 +138,34 @@ func (c *CreateDataObjectTestConfig) GetTaskRun() *v1beta1.TaskRun {
 					Value: v1beta1.ArrayOrString{
 						Type:      v1beta1.ParamTypeString,
 						StringVal: ToStringBoolean(c.TaskData.AllowReplace),
+					},
+				},
+				{
+					Name: CreateDataObjectParams.DeleteObject,
+					Value: v1beta1.ArrayOrString{
+						Type:      v1beta1.ParamTypeString,
+						StringVal: ToStringBoolean(c.TaskData.DeleteObject),
+					},
+				},
+				{
+					Name: CreateDataObjectParams.DeleteObjectName,
+					Value: v1beta1.ArrayOrString{
+						Type:      v1beta1.ParamTypeString,
+						StringVal: c.TaskData.DeleteObjectName,
+					},
+				},
+				{
+					Name: CreateDataObjectParams.DeleteObjectKind,
+					Value: v1beta1.ArrayOrString{
+						Type:      v1beta1.ParamTypeString,
+						StringVal: c.TaskData.DeleteObjectKind,
+					},
+				},
+				{
+					Name: CreateDataObjectParams.DataObjectNamespace,
+					Value: v1beta1.ArrayOrString{
+						Type:      v1beta1.ParamTypeString,
+						StringVal: c.TaskData.dataObjectNamespace,
 					},
 				},
 			},

--- a/tasks/create-data-object/README.md
+++ b/tasks/create-data-object/README.md
@@ -13,6 +13,9 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **namespace**: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
 - **waitForSuccess**: Set to `true` or `false` if container should wait for Ready condition of the data object.
 - **allowReplace**: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
+- **deleteObject**: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+- **deleteObjectKind**: Kind of the data object to delete. This parameter is used only for Delete operation.
+- **deleteObjectName**: Name of the data object to delete. This parameter is used only for Delete operation.
   
 ### Results
 

--- a/tasks/create-data-object/manifests/create-data-object.yaml
+++ b/tasks/create-data-object/manifests/create-data-object.yaml
@@ -18,6 +18,7 @@ spec:
     - name: manifest
       description: YAML manifest of a data object to be created.
       type: string
+      default: ''
     - name: namespace
       description: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
       default: ""
@@ -30,6 +31,18 @@ spec:
       description: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: deleteObject
+      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
+    - name: deleteObjectKind
+      description: Kind of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
+    - name: deleteObjectName
+      description: Name of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
   results:
     - name: name
       description: The name of the data object that was created.
@@ -51,6 +64,12 @@ spec:
           value: $(params.waitForSuccess)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: DELETE_OBJECT
+          value: $(params.deleteObject)
+        - name: DELETE_OBJECT_KIND
+          value: $(params.deleteObjectKind)
+        - name: DELETE_OBJECT_NAME
+          value: $(params.deleteObjectName)
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/templates/create-data-object/manifests/create-data-object.yaml
+++ b/templates/create-data-object/manifests/create-data-object.yaml
@@ -18,6 +18,7 @@ spec:
     - name: manifest
       description: YAML manifest of a data object to be created.
       type: string
+      default: ''
     - name: namespace
       description: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
       default: ""
@@ -30,6 +31,18 @@ spec:
       description: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: deleteObject
+      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      default: 'false'
+      type: string
+    - name: deleteObjectKind
+      description: Kind of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
+    - name: deleteObjectName
+      description: Name of the data object to delete. This parameter is used only for Delete operation.
+      default: ""
+      type: string
   results:
     - name: name
       description: The name of the data object that was created.
@@ -51,3 +64,9 @@ spec:
           value: $(params.waitForSuccess)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: DELETE_OBJECT
+          value: $(params.deleteObject)
+        - name: DELETE_OBJECT_KIND
+          value: $(params.deleteObjectKind)
+        - name: DELETE_OBJECT_NAME
+          value: $(params.deleteObjectName)


### PR DESCRIPTION
**What this PR does / why we need it**:
add delete option to create-data-object task

When DeleteObject is set, Name and ObjectKind param has to be specified.
This functionality can delete single datavolume or datasource

**Release note**:
```
add delete option to create-data-object task
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
