### PR TITLE
remove create-data-object dockerfile

### DIFF
--- a/modules/create-data-object/build/create-data-object/Dockerfile
+++ b/modules/create-data-object/build/create-data-object/Dockerfile
@@ -1,4 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
-RUN microdnf install -y golang-1.17.* && microdnf clean all
-
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
**What this PR does / why we need it**:
remove create-data-object dockerfile
This dockerfile is no longer needed

**Release note**:
```
NONE
```
