### PR TITLE
bump golang version to 1.18.4

### DIFF
--- a/modules/copy-template/build/copy-template/Dockerfile
+++ b/modules/copy-template/build/copy-template/Dockerfile
@@ -5,7 +5,7 @@ ENV TASK_NAME=copy-template \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
 
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 ENV PATH=$PATH:/usr/local/go/bin
 

--- a/modules/create-vm/build/create-vm/Dockerfile
+++ b/modules/create-vm/build/create-vm/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=create-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=disk-virt-customize \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=disk-virt-sysprep \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/execute-in-vm/build/execute-in-vm/Dockerfile
+++ b/modules/execute-in-vm/build/execute-in-vm/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=execute-in-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
+++ b/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=generate-ssh-keys \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/modify-data-object/build/modify-data-object/Dockerfile
+++ b/modules/modify-data-object/build/modify-data-object/Dockerfile
@@ -3,7 +3,7 @@ RUN microdnf install -y tar gzip && microdnf clean all
 ENV TASK_NAME=modify-data-object \
     GOFLAGS="-mod=vendor"
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/modify-vm-template/build/modify-vm-template/Dockerfile
+++ b/modules/modify-vm-template/build/modify-vm-template/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=modify-vm-template \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
+++ b/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
@@ -4,7 +4,7 @@ ENV TASK_NAME=wait-for-vmi-status \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl -L https://go.dev/dl/go1.18.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go


### PR DESCRIPTION
**What this PR does / why we need it**:
bump golang version to 1.18.4

**Release note**:
```
bump golang version to 1.18.4
```
