### PR TITLE
disk-virt-[customize|sysprep]: Add more optional workspaces

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -344,12 +344,66 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
         used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
@@ -420,12 +474,66 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
-        used during the virt-sysprep run.
+        used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -615,12 +615,66 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
         used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
@@ -691,12 +745,66 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
-        used during the virt-sysprep run.
+        used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -68,9 +68,63 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
         used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -68,9 +68,63 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
-        used during the virt-sysprep run.
+        used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -68,9 +68,63 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
         used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -68,9 +68,63 @@ spec:
       persistentVolumeClaim:
         claimName: $(params.pvc)
   workspaces:
-    - name: data
+    - name: data01
       description: |
         An optional workspace that may contain files or secrets to be
-        used during the virt-sysprep run.
+        used during the virt-customize run.
       optional: true
-      mountPath: /data
+      mountPath: /data01
+    - name: data02
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data02
+    - name: data03
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data03
+    - name: data04
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data04
+    - name: data05
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data05
+    - name: data06
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data06
+    - name: data07
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data07
+    - name: data08
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data08
+    - name: data09
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data09
+    - name: data10
+      description: |
+        An optional workspace that may contain files or secrets to be
+        used during the virt-customize run.
+      optional: true
+      mountPath: /data10


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds more optional workspaces to disk-virt-customize and
disk-virt-sysprep so more ConfigMaps or Secrets can be used.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
disk-virt-[customize|sysprep] now have 10 optional workspaces to mount ConfigMaps or Secrets
```
