### PR TITLE
add skip option for tests which doesn't have to run in downstream

### DIFF
--- a/modules/modify-data-object/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/modify-data-object/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -36,6 +36,9 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 			Kind:       dataVolumeKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+			},
 			Name: name,
 		},
 		Spec: v1beta12.DataVolumeSpec{

--- a/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -36,6 +36,9 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 			Kind:       dataVolumeKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+			},
 			Name: name,
 		},
 		Spec: v1beta12.DataVolumeSpec{

--- a/modules/tests/test/create_vm_common_test.go
+++ b/modules/tests/test/create_vm_common_test.go
@@ -23,7 +23,11 @@ import (
 
 var _ = Describe("Create VM", func() {
 	f := framework.NewFramework()
-
+	BeforeEach(func() {
+		if f.TestOptions.SkipCreateVMFromManifestTests {
+			Skip("skipCreateVMFromManifestTests is set to true, skipping tests")
+		}
+	})
 	for _, c := range []CreateVMMode{CreateVMTemplateMode, CreateVMVMManifestMode} {
 		createMode := c
 		Context(string(createMode), func() {

--- a/modules/tests/test/create_vm_from_manifest_test.go
+++ b/modules/tests/test/create_vm_from_manifest_test.go
@@ -21,6 +21,12 @@ var _ = Describe("Create VM from manifest", func() {
 			}
 		})
 
+	BeforeEach(func() {
+		if f.TestOptions.SkipCreateVMFromManifestTests {
+			Skip("skipCreateVMFromManifestTests is set to true, skipping tests")
+		}
+	})
+
 	DescribeTable("taskrun fails and no VM is created", func(config *testconfigs.CreateVMTestConfig) {
 		f.TestSetup(config)
 

--- a/modules/tests/test/execute_and_cleanup_vm_test.go
+++ b/modules/tests/test/execute_and_cleanup_vm_test.go
@@ -35,6 +35,13 @@ exit 5
 
 var _ = Describe("Execute in VM / Cleanup VM", func() {
 	f := framework.NewFramework()
+
+	BeforeEach(func() {
+		if f.TestOptions.SkipExecuteInVMTests {
+			Skip("skipExecuteInVMTests is set to true, skipping tests")
+		}
+	})
+
 	sshConnectionInfo := map[string]string{
 		"type":                             "ssh",
 		"user":                             "fedora",

--- a/modules/tests/test/framework/testoptions/test-options.go
+++ b/modules/tests/test/framework/testoptions/test-options.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
-	"k8s.io/client-go/util/homedir"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
+	"k8s.io/client-go/util/homedir"
 )
 
 var deployNamespace string
@@ -18,15 +19,21 @@ var kubeConfigPath string
 var scope string
 var debug string
 var isOKD string
+var skipCreateVMFromManifestTests string
+var skipExecuteInVMTests string
+var skipGenerateSSHKeysTests string
 
 type TestOptions struct {
-	DeployNamespace string
-	TestNamespace   string
-	StorageClass    string
-	KubeConfigPath  string
-	TestScope       constants.TestScope
-	EnvScope        constants.EnvScope
-	Debug           bool
+	DeployNamespace               string
+	TestNamespace                 string
+	StorageClass                  string
+	KubeConfigPath                string
+	TestScope                     constants.TestScope
+	EnvScope                      constants.EnvScope
+	Debug                         bool
+	SkipCreateVMFromManifestTests bool
+	SkipExecuteInVMTests          bool
+	SkipGenerateSSHKeysTests      bool
 
 	CommonTemplatesVersion string
 
@@ -41,6 +48,9 @@ func init() {
 	flag.StringVar(&isOKD, "is-okd", "", "Set to true if running on OKD. One of: true|false")
 	flag.StringVar(&scope, "scope", "", "Scope of the tests. One of: cluster|namespace")
 	flag.StringVar(&debug, "debug", "", "Debug keeps all the resources alive after the tests complete. One of: true|false")
+	flag.StringVar(&skipCreateVMFromManifestTests, "skip-create-vm-from-manifests-tests", "", "Skip create vm from manifests test suite. One of: true|false")
+	flag.StringVar(&skipExecuteInVMTests, "skip-execute-in-vm-tests", "", "Skip execute in vm test suite. One of: true|false")
+	flag.StringVar(&skipGenerateSSHKeysTests, "skip-generate-ssh-keys-tests", "", "Skip generate ssh keys suite. One of: true|false")
 }
 
 func InitTestOptions(testOptions *TestOptions) error {
@@ -82,6 +92,10 @@ func InitTestOptions(testOptions *TestOptions) error {
 	testOptions.Debug = strings.ToLower(debug) == "true"
 
 	testOptions.targetNamespaces = testOptions.resolveNamespaces()
+
+	testOptions.SkipCreateVMFromManifestTests = strings.ToLower(skipCreateVMFromManifestTests) == "true"
+	testOptions.SkipExecuteInVMTests = strings.ToLower(skipExecuteInVMTests) == "true"
+	testOptions.SkipGenerateSSHKeysTests = strings.ToLower(skipGenerateSSHKeysTests) == "true"
 
 	return nil
 }

--- a/modules/tests/test/generate_ssh_keys_test.go
+++ b/modules/tests/test/generate_ssh_keys_test.go
@@ -18,6 +18,12 @@ import (
 var _ = Describe("Generate SSH Keys", func() {
 	f := framework.NewFramework()
 
+	BeforeEach(func() {
+		if f.TestOptions.SkipGenerateSSHKeysTests {
+			Skip("skipGenerateSSHKeysTests is set to true, skipping tests")
+		}
+	})
+
 	DescribeTable("taskrun fails and no Secrets are created", func(config *testconfigs.GenerateSshKeysTestConfig) {
 		f.TestSetup(config)
 

--- a/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -36,6 +36,9 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 			Kind:       dataVolumeKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+			},
 			Name: name,
 		},
 		Spec: v1beta12.DataVolumeSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
add skip option for tests which doesn't have to run in downstream

add cdi annotation to bind immediatelly for datavolume tests, otherwise datavolumes stays in waitForFirstConsumer state and test fails.

These changes are needed to be able to run tests in downstream

**Release note**:
```
NONE
```
