### PR TITLE
remove securityContext.runAsUser from disk-virt tasks

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -319,10 +319,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'
@@ -449,10 +445,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -590,10 +590,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'
@@ -720,10 +716,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -25,6 +25,8 @@ ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_NAME=${TASK_NAME} \
     HOME=/home/${TASK_NAME}
 
+USER root
+
 # install libguestfs rhsrvany.exe win dependency for virt-customize
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe
 
@@ -32,7 +34,7 @@ COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tool
 COPY --from=taskBuilder /${TASK_NAME} ${ENTRY_CMD}
 COPY build/${TASK_NAME}/bin /usr/local/bin
 
-#RUN  /usr/local/bin/user_setup
+RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["--help"]
 

--- a/modules/disk-virt-customize/pkg/execute/executor.go
+++ b/modules/disk-virt-customize/pkg/execute/executor.go
@@ -1,16 +1,17 @@
 package execute
 
 import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-customize/pkg/constants"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-customize/pkg/utils/log"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-customize/pkg/utils/parse"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/exit"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/options"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/zerrors"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 type Executor struct {
@@ -33,7 +34,7 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 		"-Jxf",
 		applianceArchivePath,
 		"-C",
-		"/mnt",
+		"/home/disk-virt-customize",
 	}
 
 	log.GetLogger().Debug("extracting guestfs appliance with tar " + strings.Join(opts, " "))
@@ -44,7 +45,10 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	return os.Remove(applianceArchivePath)
+
+	os.Setenv("LIBGUESTFS_PATH", "/home/disk-virt-customize/appliance")
+
+	return nil
 }
 
 func (e *Executor) Execute() error {

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -23,7 +23,9 @@ ENV TASK_NAME=disk-virt-sysprep
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_UID=1001 \
     USER_NAME=${TASK_NAME} \
-    HOME=/home/${TASK_NAME} 
+    HOME=/home/${TASK_NAME}
+
+USER root
 
 # install libguestfs rhsrvany.exe win dependency for virt-sysprep
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe
@@ -32,7 +34,7 @@ COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tool
 COPY --from=taskBuilder /${TASK_NAME} ${ENTRY_CMD}
 COPY build/${TASK_NAME}/bin /usr/local/bin
 
-#RUN  /usr/local/bin/user_setup
+RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["--help"]
 

--- a/modules/disk-virt-sysprep/pkg/execute/executor.go
+++ b/modules/disk-virt-sysprep/pkg/execute/executor.go
@@ -1,16 +1,17 @@
 package execute
 
 import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-sysprep/pkg/constants"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-sysprep/pkg/utils/log"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-sysprep/pkg/utils/parse"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/exit"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/options"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/zerrors"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 type Executor struct {
@@ -33,7 +34,7 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 		"-Jxf",
 		applianceArchivePath,
 		"-C",
-		"/mnt",
+		"/home/disk-virt-sysprep",
 	}
 
 	log.GetLogger().Debug("extracting guestfs appliance with tar " + strings.Join(opts, " "))
@@ -44,7 +45,10 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	return os.Remove(applianceArchivePath)
+
+	os.Setenv("LIBGUESTFS_PATH", "/home/disk-virt-sysprep/appliance")
+
+	return nil
 }
 
 func (e *Executor) Execute() error {

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -43,10 +43,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -43,10 +43,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -43,10 +43,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -43,10 +43,6 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-        - name: LIBGUESTFS_PATH
-          value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
in ocp 4.12 running under root causes an issue with permissions.
This PR removes the securityContext.runAsUser from disk-virt tasks
manifests, and updates the code to untar libguestfs appliance files to
${HOME}. After untar, script sets correct LIBGUESTFS_PATH env variable.
With this approach, the script does not have to run under root.

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
