### PR TITLE
disable garbage collector in datavolume tests by adding special annotation

### DIFF
--- a/modules/modify-data-object/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/modify-data-object/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -38,6 +38,7 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+				"cdi.kubevirt.io/storage.deleteAfterCompletion":    "false",
 			},
 			Name: name,
 		},

--- a/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -38,6 +38,7 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+				"cdi.kubevirt.io/storage.deleteAfterCompletion":    "false",
 			},
 			Name: name,
 		},

--- a/modules/tests/test/pipelines_test.go
+++ b/modules/tests/test/pipelines_test.go
@@ -53,7 +53,8 @@ kind: DataVolume
 metadata:
   name: test-dv
   annotations:
-  cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion:    "false"
 spec:
   pvc:
     resources:
@@ -108,7 +109,8 @@ kind: DataVolume
 metadata:
   name: test-dv-updated
   annotations:
-  cdi.kubevirt.io/storage.bind.immediate.requested: \"true\"
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+    cdi.kubevirt.io/storage.deleteAfterCompletion:    "false"
 spec:
   pvc:
     resources:

--- a/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
+++ b/modules/tests/vendor/github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/datavolume/datavolumes.go
@@ -38,6 +38,7 @@ func NewBlankDataVolume(name string) *TestDataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"cdi.kubevirt.io/storage.bind.immediate.requested": "true",
+				"cdi.kubevirt.io/storage.deleteAfterCompletion":    "false",
 			},
 			Name: name,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
disable garbage collector in datavolume tests by adding special annotation

**Release note**:
```
NONE
```
