### PR TITLE
[release-v0.9] hardcode older cdi version to prevent automatic DV garbage collecting

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -9,8 +9,7 @@ fi
 KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+CDI_VERSION="v1.54.0"
 
 TEKTON_VERSION=$(curl -s https://api.github.com/repos/tektoncd/operator/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')


### PR DESCRIPTION
**What this PR does / why we need it**:
hardcode older cdi version to prevent automatic DV garbage collecting
CDI 1.55.0 introduced automatic GC of finished DV. Tests in v0.9 are not prepared for it and I don't want to introduce any new code which updates behaviour of tests.

Signed-off-by: Karel Šimon <ksimon@redhat.com>
**Release note**:
```
NONE
```
