### PR TITLE
add deploy namespace to e2e test

### DIFF
--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -330,7 +330,8 @@ var _ = Describe("Create VM from template", func() {
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-common-template")),
 				},
-				IsCommonTemplate: true,
+				IsCommonTemplate:  true,
+				VMTargetNamespace: DeployTargetNS,
 				DataVolumesToCreate: []*datavolume.TestDataVolume{
 					datavolume.NewBlankDataVolume("common-templates-src-dv"),
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
add deploy namespace to e2e test
in d/s one test is failing, due to missing namespace during creation of VM. This commit adds it.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE
```
