### PR TITLE
[release-v0.9] Remove runAs from disk-virt tasks

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -444,8 +444,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'
@@ -513,8 +511,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -715,8 +715,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'
@@ -784,8 +782,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -25,6 +25,8 @@ ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_NAME=${TASK_NAME} \
     HOME=/home/${TASK_NAME}
 
+USER root
+
 # install libguestfs rhsrvany.exe win dependency for virt-customize
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe
 
@@ -32,7 +34,7 @@ COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tool
 COPY --from=taskBuilder /${TASK_NAME} ${ENTRY_CMD}
 COPY build/${TASK_NAME}/bin /usr/local/bin
 
-#RUN  /usr/local/bin/user_setup
+RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["--help"]
 

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -25,6 +25,8 @@ ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_NAME=${TASK_NAME} \
     HOME=/home/${TASK_NAME} 
 
+USER root
+
 # install libguestfs rhsrvany.exe win dependency for virt-sysprep
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe
 
@@ -32,7 +34,7 @@ COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tool
 COPY --from=taskBuilder /${TASK_NAME} ${ENTRY_CMD}
 COPY build/${TASK_NAME}/bin /usr/local/bin
 
-#RUN  /usr/local/bin/user_setup
+RUN  /usr/local/bin/user_setup
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["--help"]
 

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -45,8 +45,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -45,8 +45,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -45,8 +45,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -45,8 +45,6 @@ spec:
           value: direct
         - name: LIBGUESTFS_PATH
           value: /mnt/appliance
-      securityContext:
-        runAsUser: 0
       resources:
         limits:
           devices.kubevirt.io/kvm: '1'


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove runAs from disk-virt tasks
these tasks don't have to run as root with latest changes. this commit removes the requirement to run as root

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:

```
Remove runAsUser from disk-virt tasks

```
