### PR TITLE
fix:remove namespace when processing template

### DIFF
--- a/modules/create-vm/pkg/templates/template-provider.go
+++ b/modules/create-vm/pkg/templates/template-provider.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"context"
+
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/zerrors"
 	templatev1 "github.com/openshift/api/template/v1"
 	tempclient "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
@@ -33,6 +34,7 @@ func (t *templateProvider) Get(namespace string, name string) (*templatev1.Templ
 
 func (t *templateProvider) Process(namespace string, template *templatev1.Template, paramValues map[string]string) (*templatev1.Template, error) {
 	temp := template.DeepCopy()
+	temp.Namespace = ""
 	params := temp.Parameters
 
 	var paramsError zerrors.MultiError
@@ -58,5 +60,7 @@ func (t *templateProvider) Process(namespace string, template *templatev1.Templa
 	if err != nil {
 		return nil, err
 	}
+	//setting namespace back for usage in VM labels
+	processedTemplate.Namespace = template.Namespace
 	return processedTemplate, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix:remove namespace when processing template
In d/s e2e when trying to process template, api replied with panic
(panic: the namespace of the provided object does not match the
namespace sent on the request), because namespace send in request
is different than namespace in original template. This can be solved
by removing namespace from processed template and specifying only
namespace in request

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
NONE

```
