### PR TITLE
feat: add modify-windows-iso-file task

### DIFF
--- a/configs/modify-windows-iso-file.yaml
+++ b/configs/modify-windows-iso-file.yaml
@@ -1,0 +1,5 @@
+task_name: modify-windows-iso-file
+task_category: modify-windows-iso-file
+extract_iso_image: quay.io/kubevirt/tekton-task-disk-virt-customize
+modify_iso_image: quay.io/kubevirt/tekton-task-modify-data-object
+create_iso_image: quay.io/kubevirt/tekton-task-modify-data-object

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -854,6 +854,120 @@ apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
   annotations:
+    task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task
+  labels:
+    task.kubevirt.io/type: modify-windows-iso-file
+    task.kubevirt.io/category: modify-windows-iso-file
+  name: modify-windows-iso-file
+spec:
+  params:
+    - name: pvcName
+      description: PersistentVolumeClaim which contains windows iso.
+      type: string
+      default: ""
+  steps:
+    - name: modify-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+
+        export LIBGUESTFS_PATH=/usr/local/lib/guestfs/appliance
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export EFI_BOOT="${ISO_FILES_PATH}/efi/microsoft/boot"
+        export TARGET_IMG_FILE_PATH="tmp/target-pvc/disk.img"
+
+        guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
+ 
+        chmod u+w "${ISO_FILES_PATH}/efi" "${ISO_FILES_PATH}/efi/microsoft" "${ISO_FILES_PATH}/efi/microsoft/boot"
+        chmod u+w "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi" "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/cdboot_noprompt.efi"
+
+        rm "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi"
+
+        mv "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/efisys.bin"
+        mv "${EFI_BOOT}/cdboot_noprompt.efi" "${EFI_BOOT}/cdboot.efi"
+      env:
+        - name: "LIBGUESTFS_BACKEND"
+          value: "direct"
+        - name: "HOME"
+          value: "/usr/local/lib/guestfs/appliance"
+      resources:
+        limits:
+          devices.kubevirt.io/kvm: '1'
+        requests:
+          devices.kubevirt.io/kvm: '1'
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+    - name: create-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-modify-data-object:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -ex
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+
+        xorriso -as mkisofs -no-emul-boot \
+            -e "efi/microsoft/boot/efisys.bin" \
+            -boot-load-size 1 \
+            -iso-level 4 \
+            -J -l -D -N \
+            -joliet-long \
+            -relaxed-filenames \
+            -V "WINDOWS" \
+            -o ${ISO_FILE_PATH} ${ISO_FILES_PATH}
+      volumeMounts:
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+    - name: convert-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+        export TARGET_IMG_FILE_PATH="/tmp/target-pvc/disk.img"
+
+        rm ${TARGET_IMG_FILE_PATH}
+        qemu-img convert -t writeback -p -O raw ${ISO_FILE_PATH} ${TARGET_IMG_FILE_PATH}
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+  volumes:
+    - name: target-pvc
+      persistentVolumeClaim:
+        claimName: "$(params.pvcName)"
+    - name: extracted-iso-files
+      emptyDir:
+        sizeLimit: 7Gi
+    - name: iso-file
+      emptyDir:
+        sizeLimit: 7Gi
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task
     vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1309,6 +1309,120 @@ apiVersion: tekton.dev/v1beta1
 kind: ClusterTask
 metadata:
   annotations:
+    task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task
+  labels:
+    task.kubevirt.io/type: modify-windows-iso-file
+    task.kubevirt.io/category: modify-windows-iso-file
+  name: modify-windows-iso-file
+spec:
+  params:
+    - name: pvcName
+      description: PersistentVolumeClaim which contains windows iso.
+      type: string
+      default: ""
+  steps:
+    - name: modify-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+
+        export LIBGUESTFS_PATH=/usr/local/lib/guestfs/appliance
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export EFI_BOOT="${ISO_FILES_PATH}/efi/microsoft/boot"
+        export TARGET_IMG_FILE_PATH="tmp/target-pvc/disk.img"
+
+        guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
+ 
+        chmod u+w "${ISO_FILES_PATH}/efi" "${ISO_FILES_PATH}/efi/microsoft" "${ISO_FILES_PATH}/efi/microsoft/boot"
+        chmod u+w "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi" "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/cdboot_noprompt.efi"
+
+        rm "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi"
+
+        mv "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/efisys.bin"
+        mv "${EFI_BOOT}/cdboot_noprompt.efi" "${EFI_BOOT}/cdboot.efi"
+      env:
+        - name: "LIBGUESTFS_BACKEND"
+          value: "direct"
+        - name: "HOME"
+          value: "/usr/local/lib/guestfs/appliance"
+      resources:
+        limits:
+          devices.kubevirt.io/kvm: '1'
+        requests:
+          devices.kubevirt.io/kvm: '1'
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+    - name: create-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-modify-data-object:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -ex
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+
+        xorriso -as mkisofs -no-emul-boot \
+            -e "efi/microsoft/boot/efisys.bin" \
+            -boot-load-size 1 \
+            -iso-level 4 \
+            -J -l -D -N \
+            -joliet-long \
+            -relaxed-filenames \
+            -V "WINDOWS" \
+            -o ${ISO_FILE_PATH} ${ISO_FILES_PATH}
+      volumeMounts:
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+    - name: convert-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+        export TARGET_IMG_FILE_PATH="/tmp/target-pvc/disk.img"
+
+        rm ${TARGET_IMG_FILE_PATH}
+        qemu-img convert -t writeback -p -O raw ${ISO_FILE_PATH} ${TARGET_IMG_FILE_PATH}
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+  volumes:
+    - name: target-pvc
+      persistentVolumeClaim:
+        claimName: "$(params.pvcName)"
+    - name: extracted-iso-files
+      emptyDir:
+        sizeLimit: 7Gi
+    - name: iso-file
+      emptyDir:
+        sizeLimit: 7Gi
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task
     vmiNamespace.params.task.kubevirt.io/type: namespace
   labels:

--- a/modules/modify-data-object/build/modify-data-object/Dockerfile
+++ b/modules/modify-data-object/build/modify-data-object/Dockerfile
@@ -8,10 +8,11 @@ ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM quay.io/centos/centos:stream9
 ENV TASK_NAME=modify-data-object
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME}
 
+RUN dnf install -y xorriso
 # install task binary
 COPY --from=builder /${TASK_NAME} ${ENTRY_CMD}
 

--- a/modules/modify-data-object/pkg/constants/constants.go
+++ b/modules/modify-data-object/pkg/constants/constants.go
@@ -26,7 +26,7 @@ const (
 // WaitForSuccess
 const (
 	PollInterval                 = 15 * time.Second
-	PollTimeout                  = 600 * time.Second
+	PollTimeout                  = 3600 * time.Second
 	UnusualRestartCountThreshold = 3
 	ReasonError                  = "Error"
 )

--- a/tasks/modify-windows-iso-file/README.md
+++ b/tasks/modify-windows-iso-file/README.md
@@ -1,0 +1,13 @@
+# Modify Windows ISO file
+
+This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of win 11 installation.
+
+### Parameters
+
+- **pvcName**: PersistentVolumeClaim which contains windows iso.
+
+
+### Usage
+
+Please see [examples](examples) on how to run iso modification task.
+The task run has to specify spec.podTemplate.securityContext! See [examples](examples) for example how to specify it.

--- a/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
+++ b/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: modify-windows-iso-file-taskrun
+spec:
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+  taskRef:
+    kind: ClusterTask
+    name: modify-windows-iso-file
+  params:
+  - name: pvcName
+    value: w11

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
+    task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task
+  labels:
+    task.kubevirt.io/type: modify-windows-iso-file
+    task.kubevirt.io/category: modify-windows-iso-file
+  name: modify-windows-iso-file
+spec:
+  params:
+    - name: pvcName
+      description: PersistentVolumeClaim which contains windows iso.
+      type: string
+      default: ""
+  steps:
+    - name: modify-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+
+        export LIBGUESTFS_PATH=/usr/local/lib/guestfs/appliance
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export EFI_BOOT="${ISO_FILES_PATH}/efi/microsoft/boot"
+        export TARGET_IMG_FILE_PATH="tmp/target-pvc/disk.img"
+
+        guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
+ 
+        chmod u+w "${ISO_FILES_PATH}/efi" "${ISO_FILES_PATH}/efi/microsoft" "${ISO_FILES_PATH}/efi/microsoft/boot"
+        chmod u+w "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi" "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/cdboot_noprompt.efi"
+
+        rm "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi"
+
+        mv "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/efisys.bin"
+        mv "${EFI_BOOT}/cdboot_noprompt.efi" "${EFI_BOOT}/cdboot.efi"
+      env:
+        - name: "LIBGUESTFS_BACKEND"
+          value: "direct"
+        - name: "HOME"
+          value: "/usr/local/lib/guestfs/appliance"
+      resources:
+        limits:
+          devices.kubevirt.io/kvm: '1'
+        requests:
+          devices.kubevirt.io/kvm: '1'
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+    - name: create-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-modify-data-object:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -ex
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+
+        xorriso -as mkisofs -no-emul-boot \
+            -e "efi/microsoft/boot/efisys.bin" \
+            -boot-load-size 1 \
+            -iso-level 4 \
+            -J -l -D -N \
+            -joliet-long \
+            -relaxed-filenames \
+            -V "WINDOWS" \
+            -o ${ISO_FILE_PATH} ${ISO_FILES_PATH}
+      volumeMounts:
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+    - name: convert-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "quay.io/kubevirt/tekton-task-disk-virt-customize:v0.12.1"
+      script: |
+        #!/bin/bash
+        set -x
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+        export TARGET_IMG_FILE_PATH="/tmp/target-pvc/disk.img"
+
+        rm ${TARGET_IMG_FILE_PATH}
+        qemu-img convert -t writeback -p -O raw ${ISO_FILE_PATH} ${TARGET_IMG_FILE_PATH}
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+  volumes:
+    - name: target-pvc
+      persistentVolumeClaim:
+        claimName: "$(params.pvcName)"
+    - name: extracted-iso-files
+      emptyDir:
+        sizeLimit: 7Gi
+    - name: iso-file
+      emptyDir:
+        sizeLimit: 7Gi

--- a/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
+++ b/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: {{ item.taskrun_with_flavor_name }}
+spec:
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      fsGroup: 1001
+  taskRef:
+    kind: ClusterTask
+    name: {{ task_name }}
+  params:
+  - name: pvcName
+    value: w11

--- a/templates/modify-windows-iso-file/generate-task.yaml
+++ b/templates/modify-windows-iso-file/generate-task.yaml
@@ -1,0 +1,40 @@
+---
+- connection: local
+  hosts: 127.0.0.1
+  gather_facts: no
+  vars_files:
+    - ../../configs/modify-windows-iso-file.yaml
+    - ../../scripts/ansible/enums.yaml
+    - ../../scripts/ansible/common.yaml
+  tasks:
+    - name: Init
+      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+    - name: "Generate {{ task_name }} task"
+      template:
+        src: "{{ manifest_templates_dir }}/{{ task_category }}.yaml"
+        dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
+        mode: "{{ default_file_mode }}"
+    - name: Prepare examples dist directory
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ examples_output_dir }}"
+        - "{{ examples_taskruns_output_dir }}"
+    - name: Generate example task runs
+      template:
+        src: "{{ examples_templates_dir }}/{{ task_name }}-taskrun.yaml"
+        dest: "{{ examples_taskruns_output_dir }}/{{ item.taskrun_with_flavor_name }}.yaml"
+        mode: "{{ default_file_mode }}"
+      with_items:
+        - { taskrun_with_flavor_name: "{{ task_name }}-taskrun" }
+    - name: Generate README
+      template:
+        src: "{{ readmes_templates_dir }}/README.md"
+        dest: "{{ output_dir }}/README.md"
+        mode: "{{ default_file_mode }}"
+      vars:
+        task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
+        task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
+    - name: Assemble task
+      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  annotations:
+    task.kubevirt.io/associatedServiceAccount: {{ sa_name }}
+  labels:
+    task.kubevirt.io/type: {{ task_name }}
+    task.kubevirt.io/category: {{ task_category }}
+  name: {{ task_name }}
+spec:
+  params:
+    - name: pvcName
+      description: PersistentVolumeClaim which contains windows iso.
+      type: string
+      default: ""
+  steps:
+    - name: modify-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "{{ extract_iso_image }}:{{ version }}"
+      script: |
+        #!/bin/bash
+        set -x
+
+        export LIBGUESTFS_PATH=/usr/local/lib/guestfs/appliance
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export EFI_BOOT="${ISO_FILES_PATH}/efi/microsoft/boot"
+        export TARGET_IMG_FILE_PATH="tmp/target-pvc/disk.img"
+
+        guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
+ 
+        chmod u+w "${ISO_FILES_PATH}/efi" "${ISO_FILES_PATH}/efi/microsoft" "${ISO_FILES_PATH}/efi/microsoft/boot"
+        chmod u+w "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi" "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/cdboot_noprompt.efi"
+
+        rm "${EFI_BOOT}/efisys.bin" "${EFI_BOOT}/cdboot.efi"
+
+        mv "${EFI_BOOT}/efisys_noprompt.bin" "${EFI_BOOT}/efisys.bin"
+        mv "${EFI_BOOT}/cdboot_noprompt.efi" "${EFI_BOOT}/cdboot.efi"
+      env:
+        - name: "LIBGUESTFS_BACKEND"
+          value: "direct"
+        - name: "HOME"
+          value: "/usr/local/lib/guestfs/appliance"
+      resources:
+        limits:
+          devices.kubevirt.io/kvm: '1'
+        requests:
+          devices.kubevirt.io/kvm: '1'
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+    - name: create-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "{{ create_iso_image }}:{{ version }}"
+      script: |
+        #!/bin/bash
+        set -ex
+        export ISO_FILES_PATH="/tmp/extracted-iso-files"
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+
+        xorriso -as mkisofs -no-emul-boot \
+            -e "efi/microsoft/boot/efisys.bin" \
+            -boot-load-size 1 \
+            -iso-level 4 \
+            -J -l -D -N \
+            -joliet-long \
+            -relaxed-filenames \
+            -V "WINDOWS" \
+            -o ${ISO_FILE_PATH} ${ISO_FILES_PATH}
+      volumeMounts:
+        - mountPath: /tmp/extracted-iso-files/
+          name: extracted-iso-files
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+    - name: convert-iso-file
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+      image: "{{ extract_iso_image }}:{{ version }}"
+      script: |
+        #!/bin/bash
+        set -x
+        export ISO_FILE_PATH="/tmp/iso-file/disk.iso"
+        export TARGET_IMG_FILE_PATH="/tmp/target-pvc/disk.img"
+
+        rm ${TARGET_IMG_FILE_PATH}
+        qemu-img convert -t writeback -p -O raw ${ISO_FILE_PATH} ${TARGET_IMG_FILE_PATH}
+      volumeMounts:
+        - mountPath: /tmp/target-pvc/
+          name: target-pvc
+        - mountPath: /tmp/iso-file/
+          name: iso-file
+  volumes:
+    - name: target-pvc
+      persistentVolumeClaim:
+        claimName: "$(params.pvcName)"
+    - name: extracted-iso-files
+      emptyDir:
+        sizeLimit: 7Gi
+    - name: iso-file
+      emptyDir:
+        sizeLimit: 7Gi

--- a/templates/modify-windows-iso-file/readmes/README.md
+++ b/templates/modify-windows-iso-file/readmes/README.md
@@ -1,0 +1,15 @@
+# Modify Windows ISO file
+
+This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of win 11 installation.
+
+### Parameters
+
+{% for item in task_yaml.spec.params %}
+- **{{ item.name }}**: {{ item.description | replace('"', '`') }}
+{% endfor %}
+
+
+### Usage
+
+Please see [examples](examples) on how to run iso modification task.
+The task run has to specify spec.podTemplate.securityContext! See [examples](examples) for example how to specify it.


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add modify-windows-iso-file task
this tasks modifies windows iso and replaces prompt bootloader with no-prompt bootloader. This helps during automation of win 11 installation.

We can't do any modifications inside iso, because by default win iso is in UDF format and read only. To extract iso the guestfish is used. After extraction, bootloader is replaced with no-prompt one. The extracted files are then packed back by xorriso. The result iso is then converted to raw format and stored back to original pvc as a replacement of original iso.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
add modify-windows-iso-file task
```
