### PR TITLE
chore: new libguestfs appliance does not need extraction

### DIFF
--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -18,14 +18,14 @@ RUN git clone https://github.com/rwmjones/rhsrvany.git
 WORKDIR /rhsrvany
 RUN autoreconf --install && autoconf && mingw32-configure --disable-dependency-tracking && make
 
-FROM quay.io/kubevirt/libguestfs-tools:v0.55.0
+FROM quay.io/kubevirt/libguestfs-tools:v0.59.0-alpha.2
 ENV TASK_NAME=disk-virt-customize
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_UID=1001 \
     USER_NAME=${TASK_NAME} \
     HOME=/home/${TASK_NAME}
 
-USER root
+USER 0
 
 # install libguestfs rhsrvany.exe win dependency for virt-customize
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe

--- a/modules/disk-virt-customize/pkg/constants/constants.go
+++ b/modules/disk-virt-customize/pkg/constants/constants.go
@@ -10,9 +10,8 @@ const (
 
 const (
 	DiskImagePath                  = "/mnt/targetpvc/disk.img"
-	GuestFSApplianceArchivePath    = "/usr/local/lib/guestfs/downloaded"
+	GuestFSApplianceArchivePath    = "/usr/local/lib/guestfs/appliance"
 	VirtCustomizeCommandsFileName  = "virt_customize_commands"
 	GuestFSApplianceArchivePathEnv = "LIBGUESTFS_APPLIANCE_ARCHIVE_PATH"
-	TargetApplianceFolderEnv       = "LIBGUESTFS_APPLIANCE_TARGET_PATH"
 	DiskVirtCustomizeHome          = "/home/disk-virt-customize"
 )

--- a/modules/disk-virt-customize/pkg/execute/executor.go
+++ b/modules/disk-virt-customize/pkg/execute/executor.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-customize/pkg/constants"
@@ -32,24 +31,7 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 		return zerrors.NewMissingRequiredError("guestfs appliance is missing at %v", applianceArchivePath)
 	}
 
-	targetFolder := env.EnvOrDefault(constants.TargetApplianceFolderEnv, constants.DiskVirtCustomizeHome)
-	opts := []string{
-		"-Jxf",
-		applianceArchivePath,
-		"-C",
-		targetFolder,
-	}
-
-	log.GetLogger().Debug("extracting guestfs appliance with tar " + strings.Join(opts, " "))
-	cmd := exec.Command("tar", opts...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	os.Setenv("LIBGUESTFS_PATH", path.Join(targetFolder, "appliance"))
+	os.Setenv("LIBGUESTFS_PATH", applianceArchivePath)
 
 	return nil
 }

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -18,14 +18,14 @@ RUN git clone https://github.com/rwmjones/rhsrvany.git
 WORKDIR /rhsrvany
 RUN autoreconf --install && autoconf && mingw32-configure --disable-dependency-tracking && make
 
-FROM quay.io/kubevirt/libguestfs-tools:v0.55.0
+FROM quay.io/kubevirt/libguestfs-tools:v0.59.0-alpha.2
 ENV TASK_NAME=disk-virt-sysprep
 ENV ENTRY_CMD=/usr/local/bin/${TASK_NAME} \
     USER_UID=1001 \
     USER_NAME=${TASK_NAME} \
     HOME=/home/${TASK_NAME}
 
-USER root
+USER 0
 
 # install libguestfs rhsrvany.exe win dependency for virt-sysprep
 COPY --from=rhsrvanyBuilder /rhsrvany/RHSrvAny/rhsrvany.exe /usr/share/virt-tools/rhsrvany.exe

--- a/modules/disk-virt-sysprep/pkg/constants/constants.go
+++ b/modules/disk-virt-sysprep/pkg/constants/constants.go
@@ -10,9 +10,8 @@ const (
 
 const (
 	DiskImagePath                  = "/mnt/targetpvc/disk.img"
-	GuestFSApplianceArchivePath    = "/usr/local/lib/guestfs/downloaded"
+	GuestFSApplianceArchivePath    = "/usr/local/lib/guestfs/appliance"
 	VirtSysprepCommandsFileName    = "virt_sysprep_commands"
 	GuestFSApplianceArchivePathEnv = "LIBGUESTFS_APPLIANCE_ARCHIVE_PATH"
-	TargetApplianceFolderEnv       = "LIBGUESTFS_APPLIANCE_TARGET_PATH"
 	DiskVirtSysprepHome            = "/home/disk-virt-sysprep"
 )

--- a/modules/disk-virt-sysprep/pkg/execute/executor.go
+++ b/modules/disk-virt-sysprep/pkg/execute/executor.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-virt-sysprep/pkg/constants"
@@ -32,24 +31,7 @@ func (e *Executor) PrepareGuestFSAppliance() error {
 		return zerrors.NewMissingRequiredError("guestfs appliance is missing at %v", applianceArchivePath)
 	}
 
-	targetFolder := env.EnvOrDefault(constants.TargetApplianceFolderEnv, constants.DiskVirtSysprepHome)
-	opts := []string{
-		"-Jxf",
-		applianceArchivePath,
-		"-C",
-		targetFolder,
-	}
-
-	log.GetLogger().Debug("extracting guestfs appliance with tar " + strings.Join(opts, " "))
-	cmd := exec.Command("tar", opts...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return err
-	}
-
-	os.Setenv("LIBGUESTFS_PATH", path.Join(targetFolder, "appliance"))
+	os.Setenv("LIBGUESTFS_PATH", applianceArchivePath)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: 
chore: new libguestfs appliance does not need extraction
new libguestfs container contains appliance, which does not need extraction. This PR updates the code of disk-virt-* tasks to use appliance files directly without untaring
Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
disk-virt-* tasks are using appliance files directly without untaring
```
