### PR TITLE
Build and push ARM images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Publish tekton images and generate release manifests
         run: |
+          sudo apt-get update -y && sudo apt-get install -y qemu-user-static
           echo ${{ secrets.QUAY_PASSWORD }} | podman login -u="${{ secrets.QUAY_BOT }}" --password-stdin quay.io
           export RELEASE_VERSION="${{ steps.get_release.outputs.tag_name }}"
           make release

--- a/makefile
+++ b/makefile
@@ -73,6 +73,8 @@ vendor:
 	cluster-test \
 	cluster-clean \
 	cluster-clean-and-skip-images \
+	build-release-images \
+	push-release-images \
 	release \
 	e2e-tests \
 	onboard-new-task-with-ci-stub \

--- a/modules/copy-template/build/copy-template/Dockerfile
+++ b/modules/copy-template/build/copy-template/Dockerfile
@@ -1,13 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=copy-template \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-
-ENV PATH=$PATH:/usr/local/go/bin
 
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go

--- a/modules/create-vm/build/create-vm/Dockerfile
+++ b/modules/create-vm/build/create-vm/Dockerfile
@@ -1,11 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=create-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
+++ b/modules/disk-virt-customize/build/disk-virt-customize/Dockerfile
@@ -1,11 +1,9 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS taskBuilder
-RUN microdnf install -y tar gzip && microdnf clean all
+RUN microdnf install -y tar gzip golang && microdnf clean all
 ENV TASK_NAME=disk-virt-customize \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
+++ b/modules/disk-virt-sysprep/build/disk-virt-sysprep/Dockerfile
@@ -1,11 +1,9 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal AS taskBuilder
-RUN microdnf install -y tar gzip && microdnf clean all
+RUN microdnf install -y tar gzip golang && microdnf clean all
 ENV TASK_NAME=disk-virt-sysprep \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/execute-in-vm/build/execute-in-vm/Dockerfile
+++ b/modules/execute-in-vm/build/execute-in-vm/Dockerfile
@@ -1,11 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y  tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=execute-in-vm \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
+++ b/modules/generate-ssh-keys/build/generate-ssh-keys/Dockerfile
@@ -1,11 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=generate-ssh-keys \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/modify-data-object/build/modify-data-object/Dockerfile
+++ b/modules/modify-data-object/build/modify-data-object/Dockerfile
@@ -1,10 +1,7 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=modify-data-object \
     GOFLAGS="-mod=vendor"
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/modify-vm-template/build/modify-vm-template/Dockerfile
+++ b/modules/modify-vm-template/build/modify-vm-template/Dockerfile
@@ -1,11 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=modify-vm-template \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
+++ b/modules/wait-for-vmi-status/build/wait-for-vmi-status/Dockerfile
@@ -1,11 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
-RUN microdnf install -y tar gzip && microdnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.9 AS builder
 ENV TASK_NAME=wait-for-vmi-status \
     GOFLAGS="-mod=vendor" \
     GO111MODULE=on
 WORKDIR /src/${TASK_NAME}
-RUN curl -L https://go.dev/dl/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
-ENV PATH=$PATH:/usr/local/go/bin
 COPY . .
 RUN	CGO_ENABLED=0 GOOS=linux go build -o /${TASK_NAME} cmd/${TASK_NAME}/main.go
 

--- a/scripts/build-release-images.sh
+++ b/scripts/build-release-images.sh
@@ -24,7 +24,7 @@ visit "${REPO_DIR}"
         visit "${TASK_NAME}"
           IMAGE_NAME_AND_TAG="tekton-task-${TASK_NAME}:${RELEASE_VERSION}"
           IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
-          podman build -f "build/${TASK_NAME}/Dockerfile" -t "${IMAGE}" .
+          podman build -f "build/${TASK_NAME}/Dockerfile" --platform=linux/amd64,linux/arm64 --manifest "${IMAGE}" .
         leave
       fi
     done

--- a/scripts/push-release-images.sh
+++ b/scripts/push-release-images.sh
@@ -27,6 +27,7 @@ visit "${REPO_DIR}"
                 echo "Pushing ${IMAGE}"
                 
                 podman push "${IMAGE}"
+                podman manifest push --all "${IMAGE}" "${IMAGE}"
             leave
         fi
     done


### PR DESCRIPTION
Build and publish multi-arch images
    
    Motivation
    ARM clusters, specifically in the world of CI/CD are becoming
    increasingly interesting and kubevirt has added arm images for of its
    components. This would make those tekton tasks consumable in thoe
    clusters.
    
    Modification
    Build and push ARM images using the qemu-user-static emulation.
    Podman build supports '--platform' switch that makes the build choose
    the qemu emulation and performs the commands inside it.
    
    Result
    An image for both arm(aarch64) and amd64(existing) and a manifest
    which contains references to those multiple architectures.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I'm not adding anytihing into the release notes because I'm not sure this is 
used in an upstream release.
I forked this repo and tested those changes on the fork and published the results to 
quay.io/rgolangh/tekton-task-create-vm:v0.0.1 so you can inspect the manifest and 
see its multi arch

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

[CNV-24917](https://issues.redhat.com//browse/CNV-24917)
