### PR TITLE
feat: add documentation for windows-customize and windows-efi-installer example pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Visit [RBAC permissions for running the tasks](docs/tasks-rbac-permissions.md) i
 
 - [wait-for-vmi-status](tasks/wait-for-vmi-status)
 
+#### Modify Windows iso
+- [modify-windows-iso-file](tasks/modify-windows-iso-file) - modifies windows iso (replaces prompt bootloader with no-promt 
+   bootloader) and replaces original iso in PVC with updated one.
+
 ## Examples
 
 #### [Unit Tester Pipeline](examples/pipelines/unit-tester) 
@@ -100,9 +104,13 @@ Then, a VM is created from such image.
 
 Downloads a Windows Source ISO into a PVC and automatically installs Windows by using a custom Answer file into a new base DV.
 
-#### [Windows 10 Customize Pipeline](examples/pipelines/windows10-customize)
+#### [Windows efi Installer Pipeline](examples/pipelines/windows-efi-installer)
 
-Applies customizations to an existing Windows 10 installation by using a custom Answer file and creates a new base DV.
+Downloads a Windows Source ISO into a PVC and automatically installs Windows 11, or 2k22 with efi enabled by using a custom Answer file into a new base DV.
+
+#### [Windows Customize Pipeline](examples/pipelines/windows10-customize)
+
+Applies customizations to an existing Windows 10, 11, 2k22 installation by using a custom Answer file and creates a new base DV.
 
 ## Development Guide
 

--- a/examples/pipelines/windows-customize/README.md
+++ b/examples/pipelines/windows-customize/README.md
@@ -1,11 +1,16 @@
-# Windows 10 Customize Pipeline
+# Windows Customize Pipeline
 
-This pipeline clones the DataVolume of a basic and generalized Windows 10 installation and runs arbitrary customization
-commands through an unattend.xml after startup  of the VM. As an example a ConfigMap which installs Microsoft SQL
-Server Express and generalizes the VM after is included (`windows10-sqlserver`). For basic setup after the first start
-of a customized VM an example unattend.xml is included in the pipeline's ConfigMap `windows10-unattend`.
+This pipeline clones the DataVolume of a basic and generalized Windows 10/11/2k22 installation and runs arbitrary customization
+commands through an unattend.xml after startup of the VM. As an example a ConfigMap which installs Microsoft SQL
+Server Express and generalizes the VM after is included (`windows-sqlserver`) or a ConfigMap that install VSCode (`windows-vs-code`). 
+For basic setup after the first start of a customized VM an example unattend.xml is included in the pipeline's ConfigMap `windows10-unattend`, 
+or `windows11-unattend`.
 
-The provided reference ConfigMap (`windows10-sqlserver`) boots Windows 10 into Audit mode, applies the customizations as
+This example pipeline can be used for running windows 10, 11 or 2k22 (or others - not tested!). Always adjust pipeline parameters 
+for windows version you are currently using(e.g. different template name, different base image name, ...). It is possible to use 
+`windows-sqlserver` config map for win11/2k22 and vice versa (`windows-vs-code` for win10/2k22).
+
+The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10/11/2k22 into Audit mode, applies the customizations as
 part of a Powershell script (ran by `SynchronousCommand`) and then generalizes the VM again. The Powershell
 script can be adapted as desired to apply other customizations.
 
@@ -14,15 +19,17 @@ A new golden template is created after a successful customization through this v
 
 ## Prerequisites
 
-- KubeVirt `v0.53.1`
-- Tekton Pipelines `v0.35.0`
+- KubeVirt `v0.59.1`
+- Tekton Pipelines `v0.44.0`
 
 ## Links
 
-- [Windows 10 Customize Pipeline for Kubernetes](https://github.com/kubevirt/tekton-tasks-operator/blob/main/data/tekton-pipelines/kubernetes/windows10-customize.yaml)
+- [Windows Customize Pipeline for Kubernetes](https://github.com/kubevirt/tekton-tasks-operator/blob/main/data/tekton-pipelines/kubernetes/windows-customize.yaml)
 - [Windows 10 Customize PipelineRun for Kubernetes](windows10-customize-pipelinerun-kubernetes.yaml)
-- [Windows 10 Customize Pipeline for OKD](https://github.com/kubevirt/tekton-tasks-operator/blob/main/data/tekton-pipelines/okd/windows10-customize.yaml)
+- [Windows Customize Pipeline for OKD](https://github.com/kubevirt/tekton-tasks-operator/blob/main/data/tekton-pipelines/okd/windows-customize.yaml)
 - [Windows 10 Customize PipelineRun for OKD](windows10-customize-pipelinerun-okd.yaml)
+- [Windows 11 Customize PipelineRun for OKD](windows11-customize-pipelinerun-okd.yaml)
+- [Windows 2k22 Customize PipelineRun for OKD](windows2k22-customize-pipelinerun-okd.yaml)
 
 ### Prepare unattend.xml ConfigMap
 
@@ -38,11 +45,11 @@ A new golden template is created after a successful customization through this v
 ```
 
 1. `create-base-dv` task creates an empty DV for the customized windows installation called `windows10-base-*`.
-2. `create-vm-from-manifest` task creates a VM called `windows10-installer-*`
+2. `create-vm-from-manifest` task creates a VM called `windows-installer-*`
    from the base DV and with the customize ConfigMap attached as a CD-ROM. (Pipeline parameter `customizeConfigMapName`)
 3. `wait-for-vmi-status` task waits until the VM shuts down.
 4. `cleanup-vm` deletes the installer VM. (also in case of failure of the previous tasks)
-5. The output artifact will be the `windows10-base-*` DV with the customized Windows installation.
+5. The output artifact will be the `windows-base-*` DV with the customized Windows installation.
    It will boot into the Windows OOBE and needs to be setup further before it can be used. (depends on the applied customizations)
 6. The `windows10-unattend` ConfigMap can be used to boot the VM into the Desktop. (depends on the applied customizations)
 
@@ -59,7 +66,7 @@ A new golden template is created after a successful customization through this v
 3. `create-vm-from-template` task creates a VM from the newly created Template.
    A DV with the customize ConfigMap will be attached as CD-ROM. (Pipeline parameter `customizeConfigMapName`)
 4. `wait-for-vmi-status` task waits until the VM shuts down.
-5. `create-base-dv` task creates an DV called `windows10-base-*`, then it clones the DV of the customize VM into the new DV.
+5. `create-base-dv` task creates an DV called `windows-base-*`, then it clones the DV of the customize VM into the new DV.
 6. `copy-template-golden` copies the template defined by the pipeline parameters `sourceTemplateName` and `sourceTemplateNamespace`
    to a new template with the name specified by parameter `goldenTemplateName` in the same namespace.
    An already existing template can be overwritten when setting `allowReplaceGoldenTemplate` to `true`.

--- a/examples/pipelines/windows-customize/windows10-customize-pipelinerun-kubernetes.yaml
+++ b/examples/pipelines/windows-customize/windows10-customize-pipelinerun-kubernetes.yaml
@@ -9,7 +9,7 @@ spec:
   - name: sourceDataVolumeNamespace
     value: INSERT_NAMESPACE_OF_SOURCE_DATAVOLUME
   pipelineRef:
-    name: windows10-customize
+    name: windows-customize
   taskRunSpecs:
     - pipelineTaskName: create-base-dv
       taskServiceAccountName: modify-data-object-task

--- a/examples/pipelines/windows-customize/windows10-customize-pipelinerun-okd.yaml
+++ b/examples/pipelines/windows-customize/windows10-customize-pipelinerun-okd.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows10-customize-run-
+spec:
+  pipelineRef:
+    name: windows-customize
+  taskRunSpecs:
+    - pipelineTaskName: copy-template-customize
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-customize
+      taskServiceAccountName: modify-vm-template-task
+    - pipelineTaskName: create-vm-from-template
+      taskServiceAccountName: create-vm-from-template-task
+    - pipelineTaskName: wait-for-vmi-status
+      taskServiceAccountName: wait-for-vmi-status-task
+    - pipelineTaskName: create-base-dv
+      taskServiceAccountName: modify-data-object-task
+    - pipelineTaskName: cleanup-vm
+      taskServiceAccountName: cleanup-vm-task
+    - pipelineTaskName: copy-template-golden
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-golden
+      taskServiceAccountName: modify-vm-template-task
+status: {}

--- a/examples/pipelines/windows-customize/windows11-customize-pipelinerun-okd.yaml
+++ b/examples/pipelines/windows-customize/windows11-customize-pipelinerun-okd.yaml
@@ -1,10 +1,17 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  generateName: windows10-customize-run-
+  generateName: windows11-customize-run-
 spec:
+  params:
+    - name: sourceTemplateName
+      value: windows11-desktop-large
+    - name: customizeTemplateName
+      value: windows11-desktop-large-customize-sqlserver
+    - name: goldenTemplateName
+      value: windows11-desktop-large-golden-sqlserver
   pipelineRef:
-    name: windows10-customize
+    name: windows-customize
   taskRunSpecs:
     - pipelineTaskName: copy-template-customize
       taskServiceAccountName: copy-template-task

--- a/examples/pipelines/windows-customize/windows2k22-customize-pipelinerun-okd.yaml
+++ b/examples/pipelines/windows-customize/windows2k22-customize-pipelinerun-okd.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows2k22-customize-run-
+spec:
+  params:
+    - name: sourceTemplateName
+      value: windows2k22-server-large
+    - name: customizeTemplateName
+      value: windows2k22-desktop-large-customize-sqlserver
+    - name: goldenTemplateName
+      value: windows2k22-desktop-large-golden-sqlserver
+  pipelineRef:
+    name: windows-customize
+  taskRunSpecs:
+    - pipelineTaskName: copy-template-customize
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-customize
+      taskServiceAccountName: modify-vm-template-task
+    - pipelineTaskName: create-vm-from-template
+      taskServiceAccountName: create-vm-from-template-task
+    - pipelineTaskName: wait-for-vmi-status
+      taskServiceAccountName: wait-for-vmi-status-task
+    - pipelineTaskName: create-base-dv
+      taskServiceAccountName: modify-data-object-task
+    - pipelineTaskName: cleanup-vm
+      taskServiceAccountName: cleanup-vm-task
+    - pipelineTaskName: copy-template-golden
+      taskServiceAccountName: copy-template-task
+    - pipelineTaskName: modify-vm-template-golden
+      taskServiceAccountName: modify-vm-template-task
+status: {}

--- a/examples/pipelines/windows-efi-installer/getisourl.py
+++ b/examples/pipelines/windows-efi-installer/getisourl.py
@@ -12,7 +12,7 @@ driver = webdriver.Chrome(options=options)
 driver.implicitly_wait(10)
 
 try:
-    driver.get("https://www.microsoft.com/en-us/software-download/windows10")
+    driver.get("https://www.microsoft.com/en-us/software-download/windows11")
 
     select_object = Select(driver.find_element(By.ID, "product-edition"))
     select_object.select_by_index(1)

--- a/examples/pipelines/windows-efi-installer/windows11-installer-pipelinerun-okd.yaml
+++ b/examples/pipelines/windows-efi-installer/windows11-installer-pipelinerun-okd.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows11-installer-run-
+spec:
+  params:
+    - name: winImageDownloadURL
+      value: >-
+       <INSERT_WINDOWS_ISO_URL>
+    - name: autounattendConfigMapName
+      value: windows11-autounattend
+    - name: sourceTemplateName
+      value: windows11-desktop-large
+    - name: sourceTemplateNamespace
+      value: openshift
+    - name: installerTemplateName
+      value: windows11-desktop-large-installer
+    - name: allowReplaceInstallerTemplate
+      value: 'true'
+    - name: baseDvName
+      value: win11
+    - name: baseDvNamespace
+      value: kubevirt-os-images
+    - name: isoDVName
+      value: win11
+    - name: allowReplaceISODV
+      value: 'false'
+  pipelineRef:
+    name: windows-efi-installer
+  timeout: 1h0m0s
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      taskPodTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001          

--- a/examples/pipelines/windows-efi-installer/windows2k22-installer-pipelinerun-okd.yaml
+++ b/examples/pipelines/windows-efi-installer/windows2k22-installer-pipelinerun-okd.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: windows2k22-installer-run-
+spec:
+  params:
+    - name: winImageDownloadURL
+      value: >-
+       <INSERT_WINDOWS_ISO_URL>
+    - name: autounattendConfigMapName
+      value: windows2k22-autounattend
+    - name: sourceTemplateName
+      value: windows2k22-server-large
+    - name: sourceTemplateNamespace
+      value: openshift
+    - name: installerTemplateName
+      value: windows2k22-server-large-installer
+    - name: allowReplaceInstallerTemplate
+      value: 'true'
+    - name: baseDvName
+      value: win2k22
+    - name: baseDvNamespace
+      value: kubevirt-os-images
+    - name: isoDVName
+      value: win2k22
+    - name: allowReplaceISODV
+      value: 'false'
+  pipelineRef:
+    name: windows-efi-installer
+  timeout: 1h0m0s
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      taskPodTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001          

--- a/tasks/modify-windows-iso-file/README.md
+++ b/tasks/modify-windows-iso-file/README.md
@@ -1,6 +1,8 @@
 # Modify Windows ISO file
 
-This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of win 11 installation.
+This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of 
+windows which requires EFI - the prompt bootloader will not continue with installation until some key is pressed. The non prompt 
+bootloader will not require any key pres.
 
 ### Parameters
 

--- a/templates/modify-windows-iso-file/readmes/README.md
+++ b/templates/modify-windows-iso-file/readmes/README.md
@@ -1,6 +1,8 @@
 # Modify Windows ISO file
 
-This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of win 11 installation.
+This tasks is modifying windows iso file. It replaces prompt bootloader with non prompt one. This helps with automation of 
+windows which requires EFI - the prompt bootloader will not continue with installation until some key is pressed. The non prompt 
+bootloader will not require any key pres.
 
 ### Parameters
 


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add documentation for windows-customize and windows-efi-installer example pipelines
This commits adds/updates documentation for windows-customize and windows-efi-installer example pipelines. These pipelines can be used to install and customize win10, 11, 2k22 from iso with tekton.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
Add documentation for windows-customize and windows-efi-installer example pipelines
```
