### PR TITLE
fix: delete pvc when datavolume is not found

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -832,6 +832,7 @@ rules:
       - pods
   - verbs:
       - get
+      - delete
     apiGroups:
       - ""
     resources:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1103,6 +1103,7 @@ rules:
       - pods
   - verbs:
       - get
+      - delete
     apiGroups:
       - ""
     resources:

--- a/tasks/modify-data-object/manifests/modify-data-object.yaml
+++ b/tasks/modify-data-object/manifests/modify-data-object.yaml
@@ -94,6 +94,7 @@ rules:
       - pods
   - verbs:
       - get
+      - delete
     apiGroups:
       - ""
     resources:

--- a/templates/modify-data-object/manifests/modify-data-object-role.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object-role.yaml
@@ -21,6 +21,7 @@ rules:
       - pods
   - verbs:
       - get
+      - delete
     apiGroups:
       - ""
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: delete pvc when datavolume is not found
Datavolumes are garbage collected, when they are successfully imported. This means that when allowReplace param is set and datavolume is GC and pvc exists, modify-data-object did not delete pvc. This PR changes the behaviour so MDO task tries to delete the existing pvc, when datavolume does not exists.

Signed-off-by: Karel Šimon <ksimon@redhat.com>

**Release note**:
```
fix: delete pvc when datavolume is not found
```
