### PR TITLE
feat: set v0.59.0-rc.0 version of kubevirt

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -5,9 +5,10 @@ set -ex
 if kubectl get namespace tekton-pipelines > /dev/null 2>&1; then
   exit 0
 fi
-
-KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+KUBEVIRT_VERSION="v0.59.0-rc.0"
+#uncoment when there is working version of kubevirt
+#KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
+#            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
 CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: set v0.59.0-rc.0 version of kubevirt
newest version of kubevirt v0.58.1 is not working. To unblock ci, set version to v0.59.0-rc.0

**Release note**:
```
NONE
```
