### PR TITLE
feat: add delete PVC option for modify-data-object task

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -770,7 +770,7 @@ spec:
       type: string
       default: "false"
     - name: deleteObject
-      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      description: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
       default: 'false'
       type: string
     - name: deleteObjectKind

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1041,7 +1041,7 @@ spec:
       type: string
       default: "false"
     - name: deleteObject
-      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      description: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
       default: 'false'
       type: string
     - name: deleteObjectKind

--- a/modules/modify-data-object/pkg/constants/constants.go
+++ b/modules/modify-data-object/pkg/constants/constants.go
@@ -15,6 +15,7 @@ const (
 const (
 	DataVolumeKind = "DataVolume"
 	DataSourceKind = "DataSource"
+	PVCKind        = "PersistentVolumeClaim"
 )
 
 // Result names

--- a/modules/modify-data-object/pkg/dataobject/provider.go
+++ b/modules/modify-data-object/pkg/dataobject/provider.go
@@ -154,13 +154,15 @@ func NewDataObjectCreator(cliOptions *parse.CLIOptions) (*DataObjectCreator, err
 }
 
 func (d *DataObjectCreator) DeleteDataObject() error {
-	if d.cliOptions.DeleteObjectKind == constants.DataVolumeKind {
+	switch d.cliOptions.DeleteObjectKind {
+	case constants.DataVolumeKind:
 		return d.dataObjectProvider.DeleteDV(d.cliOptions.DataObjectNamespace, d.cliOptions.DeleteObjectName)
+	case constants.DataSourceKind:
+		return d.dataObjectProvider.DeleteDS(d.cliOptions.DataObjectNamespace, d.cliOptions.DeleteObjectName)
+	case constants.PVCKind:
+		return d.dataObjectProvider.DeletePVC(d.cliOptions.DataObjectNamespace, d.cliOptions.DeleteObjectName)
 	}
 
-	if d.cliOptions.DeleteObjectKind == constants.DataSourceKind {
-		return d.dataObjectProvider.DeleteDS(d.cliOptions.DataObjectNamespace, d.cliOptions.DeleteObjectName)
-	}
 	return errors.NewBadRequest("object-kind not defined")
 }
 

--- a/modules/modify-data-object/pkg/utils/parse/clioptions.go
+++ b/modules/modify-data-object/pkg/utils/parse/clioptions.go
@@ -126,7 +126,7 @@ func (c *CLIOptions) assertValidParams() error {
 			return zerrors.NewMissingRequiredError("%s param has to be specified", nameOptionName)
 		}
 
-		if c.DeleteObjectKind != constants.DataVolumeKind && c.DeleteObjectKind != constants.DataSourceKind {
+		if c.DeleteObjectKind != constants.DataVolumeKind && c.DeleteObjectKind != constants.DataSourceKind && c.DeleteObjectKind != constants.PVCKind {
 			return zerrors.NewMissingRequiredError("%s param has to have values %s or %s", objectKindOptionName, constants.DataVolumeKind, constants.DataSourceKind)
 		}
 		return nil

--- a/tasks/modify-data-object/README.md
+++ b/tasks/modify-data-object/README.md
@@ -13,7 +13,7 @@ Please see [RBAC permissions for running the tasks](../../docs/tasks-rbac-permis
 - **namespace**: Namespace where to create the data object. (defaults to manifest namespace or active namespace)
 - **waitForSuccess**: Set to `true` or `false` if container should wait for Ready condition of the data object.
 - **allowReplace**: Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false
-- **deleteObject**: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+- **deleteObject**: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
 - **deleteObjectKind**: Kind of the data object to delete. This parameter is used only for Delete operation.
 - **deleteObjectName**: Name of the data object to delete. This parameter is used only for Delete operation.
   

--- a/tasks/modify-data-object/manifests/modify-data-object.yaml
+++ b/tasks/modify-data-object/manifests/modify-data-object.yaml
@@ -32,7 +32,7 @@ spec:
       type: string
       default: "false"
     - name: deleteObject
-      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      description: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
       default: 'false'
       type: string
     - name: deleteObjectKind

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -32,7 +32,7 @@ spec:
       type: string
       default: "false"
     - name: deleteObject
-      description: Set to `true` or `false` if task should delete the specified datavolume or datasource. If set to 'true' the ds/dv will be deleted and all other parameters are ignored.
+      description: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
       default: 'false'
       type: string
     - name: deleteObjectKind


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add delete PVC option for modify-data-object task
This PR adds ability to delete PVC via modify-data-object task. This will help during efi pipeline, because when the imported PVC is mounted to modify-windows-iso pod, it can't be deleted, because the PVC contains finalizer to prevent dataloss when mounted to pod. We have to include the delete pvc step into efi pipeline, so the pvc can be moved to terminating state and deleted when modify-windows-iso pod is deleted

**Release note**:
```
feat: modify-data-object task can delete PVC

```
