### PR TITLE
fix: increase emptyDir size in modify-windows-iso-file task to 12Gi

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -966,10 +966,10 @@ spec:
         claimName: "$(params.pvcName)"
     - name: extracted-iso-files
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
     - name: iso-file
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1421,10 +1421,10 @@ spec:
         claimName: "$(params.pvcName)"
     - name: extracted-iso-files
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
     - name: iso-file
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
 ---
 apiVersion: tekton.dev/v1beta1
 kind: ClusterTask

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -108,7 +108,7 @@ spec:
         claimName: "$(params.pvcName)"
     - name: extracted-iso-files
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
     - name: iso-file
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -108,7 +108,7 @@ spec:
         claimName: "$(params.pvcName)"
     - name: extracted-iso-files
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi
     - name: iso-file
       emptyDir:
-        sizeLimit: 7Gi
+        sizeLimit: 12Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: increase emptyDir size in modify-windows-iso-file task to 12Gi

When using larger windows iso, 7Gi might not be enought. This commit increases the emptyFolder size to 12Gi which should be enough for most of the use cases.

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2177279

**Special notes for your reviewer**:

**Release note**:
```
 increase emptyDir size in modify-windows-iso-file task to 12Gi
```
