### PR TITLE
Replace cluster tasks with task object

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -42,9 +42,9 @@ kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releas
 # wait for tekton pipelines
 kubectl rollout status -n openshift-operators deployment/openshift-pipelines-operator --timeout 10m
 
-# wait until clustertasks tekton CRD is properly deployed
+# wait until tasks tekton CRD is properly deployed
 timeout 10m bash <<- EOF
-  until kubectl get crd clustertasks.tekton.dev; do
+  until kubectl get crd tasks.tekton.dev; do
     sleep 5
   done
 EOF

--- a/automation/e2e-tests.sh
+++ b/automation/e2e-tests.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-export SCOPE="${SCOPE:-cluster}"
 export DEV_MODE="${DEV_MODE:-false}"
 export STORAGE_CLASS="${STORAGE_CLASS:-}"
 export DEPLOY_NAMESPACE="${DEPLOY_NAMESPACE:-e2e-tests-$(shuf -i10000-99999 -n1)}"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,12 +35,6 @@ make cluster-sync
 ./scripts/cluster-sync.sh execute-in-vm
 ```
 
-You can also change the scope of the tasks to be single namespace only:
-
-```bash
-SCOPE=namespace make cluster-sync
-```
-
 ## Testing
 
 ### Running Unit Tests
@@ -55,8 +49,6 @@ make test
 ### Running E2E Tests
 ```bash
 NUM_NODES=4 make cluster-test
-# for namespace scope use
-SCOPE=namespace NUM_NODES=4 make cluster-test
 
 # clean all used resources, namespaces and images
 make cluster-clean

--- a/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
+++ b/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
@@ -27,7 +27,7 @@ spec:
         - name: waitForSuccess
           value: 'true'
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: modify-data-object
     - name: generate-ssh-keys
       params:
@@ -36,7 +36,7 @@ spec:
             - 'user:fedora'
             - 'disable-strict-host-key-checking:true'
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: generate-ssh-keys
     - name: disk-virt-customize
       params:
@@ -47,7 +47,7 @@ spec:
             install git,vim,pip
             run-command pip install flask
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: disk-virt-customize
       runAfter:
         - modify-data-object
@@ -118,7 +118,7 @@ spec:
         - disk-virt-customize
         - generate-ssh-keys
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: create-vm-from-manifest
     - name: execute-in-vm
       params:
@@ -138,5 +138,5 @@ spec:
       runAfter:
         - create-vm-from-manifest
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: execute-in-vm

--- a/examples/pipelines/unit-tester/unit-tester-pipeline.yaml
+++ b/examples/pipelines/unit-tester/unit-tester-pipeline.yaml
@@ -25,7 +25,7 @@ spec:
             - 'user:fedora'
             - 'disable-strict-host-key-checking:true'
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: generate-ssh-keys
     - name: create-vm-from-manifest
       params:
@@ -87,7 +87,7 @@ spec:
       runAfter:
         - generate-ssh-keys
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: create-vm-from-manifest
     - name: execute-in-vm
       params:
@@ -110,7 +110,7 @@ spec:
       runAfter:
         - create-vm-from-manifest
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: execute-in-vm
   finally:
     - name: cleanup-vm
@@ -135,5 +135,5 @@ spec:
               cat ${RESULT_FILES}
             fi
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: cleanup-vm

--- a/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
+++ b/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
@@ -27,7 +27,7 @@ spec:
         - name: waitForSuccess
           value: 'true'
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: modify-data-object
     - name: disk-virt-sysprep
       params:
@@ -39,7 +39,7 @@ spec:
         - name: additionalOptions
           value: "--network"
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: disk-virt-sysprep
       runAfter:
         - modify-data-object
@@ -102,5 +102,5 @@ spec:
       runAfter:
         - disk-virt-sysprep
       taskRef:
-        kind: ClusterTask
+        kind: Task
         name: create-vm-from-manifest

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: cleanup-vm-task
@@ -130,7 +130,7 @@ subjects:
     name: cleanup-vm-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: create-vm-from-manifest-task
@@ -276,7 +276,7 @@ subjects:
     name: create-vm-from-manifest-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
@@ -402,7 +402,7 @@ spec:
       mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
@@ -528,7 +528,7 @@ spec:
       mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: execute-in-vm-task
@@ -636,7 +636,7 @@ subjects:
     name: execute-in-vm-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: generate-ssh-keys-task
@@ -738,7 +738,7 @@ subjects:
     name: generate-ssh-keys-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-data-object-task
@@ -858,7 +858,7 @@ subjects:
     name: modify-data-object-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task
@@ -972,7 +972,7 @@ spec:
         sizeLimit: 12Gi
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: cleanup-vm-task
@@ -130,7 +130,7 @@ subjects:
     name: cleanup-vm-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
@@ -228,7 +228,7 @@ subjects:
     name: copy-template-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: create-vm-from-manifest-task
@@ -374,7 +374,7 @@ subjects:
     name: create-vm-from-manifest-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: create-vm-from-template-task
@@ -549,7 +549,7 @@ subjects:
     name: create-vm-from-template-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
@@ -675,7 +675,7 @@ spec:
       mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
@@ -801,7 +801,7 @@ spec:
       mountPath: /data10
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: execute-in-vm-task
@@ -909,7 +909,7 @@ subjects:
     name: execute-in-vm-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: generate-ssh-keys-task
@@ -1011,7 +1011,7 @@ subjects:
     name: generate-ssh-keys-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-data-object-task
@@ -1131,7 +1131,7 @@ subjects:
     name: modify-data-object-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
@@ -1316,7 +1316,7 @@ subjects:
     name: modify-vm-template-task
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task
@@ -1430,7 +1430,7 @@ spec:
         sizeLimit: 12Gi
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task

--- a/modules/tests/test/constants/constants.go
+++ b/modules/tests/test/constants/constants.go
@@ -1,9 +1,10 @@
 package constants
 
 import (
-	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testconstants"
 	"strings"
 	"time"
+
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testconstants"
 )
 
 const e2eNamespacePrefix = "e2e-tests"
@@ -20,13 +21,6 @@ const (
 	TestTargetNS   TargetNamespace = "test"
 	SystemTargetNS TargetNamespace = "system"
 	EmptyTargetNS  TargetNamespace = "empty"
-)
-
-type TestScope string
-
-const (
-	ClusterTestScope   TestScope = "cluster"
-	NamespaceTestScope TestScope = "namespace"
 )
 
 type EnvScope string

--- a/modules/tests/test/constants/copy-template.go
+++ b/modules/tests/test/constants/copy-template.go
@@ -1,10 +1,11 @@
 package constants
 
 const (
-	CopyTemplateClusterTaskName    = "copy-template"
-	CopyTemplateServiceAccountName = "copy-template-task"
-	CopyTemplateTaskRunName        = "taskrun-copy-template"
-	NewTemplateName                = "test-template"
+	CopyTemplateTaskName                     = "copy-template"
+	CopyTemplateServiceAccountName           = "copy-template-task"
+	CopyTemplateServiceAccountNameNamespaced = "copy-template-test"
+	CopyTemplateTaskRunName                  = "taskrun-copy-template"
+	NewTemplateName                          = "test-template"
 
 	SourceTemplateNameOptionName      = "sourceTemplateName"
 	SourceTemplateNamespaceOptionName = "sourceTemplateNamespace"

--- a/modules/tests/test/constants/create-data-object.go
+++ b/modules/tests/test/constants/create-data-object.go
@@ -1,9 +1,10 @@
 package constants
 
 const (
-	ModifyDataObjectClusterTaskName    = "modify-data-object"
-	ModifyDataObjectServiceAccountName = "modify-data-object-task"
-	ModifyDataObjectTaskrunName        = "taskrun-modify-data-object"
+	ModifyDataObjectTaskName                     = "modify-data-object"
+	ModifyDataObjectServiceAccountName           = "modify-data-object-task"
+	ModifyDataObjectServiceAccountNameNamespaced = "modify-data-object-test"
+	ModifyDataObjectTaskrunName                  = "taskrun-modify-data-object"
 
 	UnusualRestartCountThreshold = 3
 	ReasonError                  = "Error"

--- a/modules/tests/test/constants/create-vm.go
+++ b/modules/tests/test/constants/create-vm.go
@@ -1,10 +1,12 @@
 package constants
 
-const CreateVMFromTemplateClusterTaskName = "create-vm-from-template"
+const CreateVMFromTemplateTaskName = "create-vm-from-template"
 const CreateVMFromTemplateServiceAccountName = "create-vm-from-template-task"
+const CreateVMFromTemplateServiceAccountNameNamespaced = "create-vm-from-template-test"
 
-const CreateVMFromManifestClusterTaskName = "create-vm-from-manifest"
+const CreateVMFromManifestTaskName = "create-vm-from-manifest"
 const CreateVMFromManifestServiceAccountName = "create-vm-from-manifest-task"
+const CreateVMFromManifestServiceAccountNameNamespaced = "create-vm-from-manifest-test"
 
 type createVMParams struct {
 	DataVolumes               string

--- a/modules/tests/test/constants/disk-virt-libguestfs-tasks.go
+++ b/modules/tests/test/constants/disk-virt-libguestfs-tasks.go
@@ -1,7 +1,7 @@
 package constants
 
-const DiskVirtCustomizeClusterTaskName = "disk-virt-customize"
-const DiskVirtSysprepClusterTaskName = "disk-virt-sysprep"
+const DiskVirtCustomizeTaskName = "disk-virt-customize"
+const DiskVirtSysprepTaskName = "disk-virt-sysprep"
 
 type diskVirtLibguestfsTasksParams struct {
 	PVCName           string

--- a/modules/tests/test/constants/execute-in-vm.go
+++ b/modules/tests/test/constants/execute-in-vm.go
@@ -1,9 +1,9 @@
 package constants
 
-const ExecuteInVMClusterTaskName = "execute-in-vm"
+const ExecuteInVMTaskName = "execute-in-vm"
 const ExecuteInVMServiceAccountName = "execute-in-vm-task"
 
-const CleanupVMClusterTaskName = "cleanup-vm"
+const CleanupVMTaskName = "cleanup-vm"
 const CleanupVMServiceAccountName = "cleanup-vm-task"
 
 type executeOrCleanupVMParams struct {

--- a/modules/tests/test/constants/generate-ssh-keys.go
+++ b/modules/tests/test/constants/generate-ssh-keys.go
@@ -1,8 +1,9 @@
 package constants
 
 const (
-	GenerateSshKeysClusterTaskName    = "generate-ssh-keys"
-	GenerateSshKeysServiceAccountName = "generate-ssh-keys-task"
+	GenerateSshKeysTaskName                     = "generate-ssh-keys"
+	GenerateSshKeysServiceAccountName           = "generate-ssh-keys-task"
+	GenerateSshKeysServiceAccountNameNamespaced = "generate-ssh-keys-test"
 )
 
 type generateSshKeysParams struct {

--- a/modules/tests/test/constants/modify-vm-template.go
+++ b/modules/tests/test/constants/modify-vm-template.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	ModifyTemplateClusterTaskName    = "modify-vm-template"
-	ModifyTemplateServiceAccountName = "modify-vm-template-task"
-	ModifyTemplateTaskRunName        = "taskrun-modify-vm-template"
+	ModifyTemplateTaskName                     = "modify-vm-template"
+	ModifyTemplateServiceAccountName           = "modify-vm-template-task"
+	ModifyTemplateServiceAccountNameNamespaced = "modify-vm-template-test"
+	ModifyTemplateTaskRunName                  = "taskrun-modify-vm-template"
 
 	TemplateNameOptionName             = "templateName"
 	TemplateNamespaceOptionName        = "templateNamespace"

--- a/modules/tests/test/constants/wait-for-vmi-status.go
+++ b/modules/tests/test/constants/wait-for-vmi-status.go
@@ -1,8 +1,9 @@
 package constants
 
 const (
-	WaitForVMIStatusClusterTaskName    = "wait-for-vmi-status"
-	WaitForVMIStatusServiceAccountName = "wait-for-vmi-status-task"
+	WaitForVMIStatusTaskName                     = "wait-for-vmi-status"
+	WaitForVMIStatusServiceAccountName           = "wait-for-vmi-status-task"
+	WaitForVMIStatusServiceAccountNameNamespaced = "wait-for-vmi-status-test"
 )
 
 type waitForVMIStatusTasksParams struct {

--- a/modules/tests/test/copy_template_test.go
+++ b/modules/tests/test/copy_template_test.go
@@ -55,11 +55,10 @@ var _ = Describe("Copy template task", func() {
 					SourceTemplateName: testtemplate.CirrosTemplateName,
 				},
 			}),
-			Entry("[NAMESPACE SCOPED] cannot copy template in different namespace", &testconfigs.CopyTemplateTestConfig{
+			Entry("cannot copy template in different namespace", &testconfigs.CopyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-					ServiceAccount: CopyTemplateServiceAccountName,
-					ExpectedLogs:   "templates.template.openshift.io is forbidden",
-					LimitTestScope: NamespaceTestScope,
+					ServiceAccount: CopyTemplateServiceAccountNameNamespaced,
+					ExpectedLogs:   "cannot get resource \"templates\"",
 				},
 				TaskData: testconfigs.CopyTemplateTaskData{
 					SourceTemplateName:      testtemplate.CirrosTemplateName,
@@ -107,7 +106,6 @@ var _ = Describe("Copy template task", func() {
 			Entry("should create template in different namespace", &testconfigs.CopyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CopyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.CopyTemplateTaskData{
 					SourceTemplateName:      testtemplate.CirrosTemplateName,
@@ -166,7 +164,6 @@ var _ = Describe("Copy template task", func() {
 			config := &testconfigs.CopyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CopyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.CopyTemplateTaskData{
 					SourceTemplateName:      testtemplate.RhelTemplateName,
@@ -214,7 +211,6 @@ var _ = Describe("Copy template task", func() {
 			config := &testconfigs.CopyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CopyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 					ExpectedLogs:   "templates.template.openshift.io \"test-template\" already exists",
 				},
 				TaskData: testconfigs.CopyTemplateTaskData{
@@ -247,7 +243,6 @@ var _ = Describe("Copy template task", func() {
 			config := &testconfigs.CopyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: CopyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.CopyTemplateTaskData{
 					SourceTemplateName:      testtemplate.CirrosTemplateName,

--- a/modules/tests/test/create_vm_from_manifest_test.go
+++ b/modules/tests/test/create_vm_from_manifest_test.go
@@ -107,22 +107,20 @@ var _ = Describe("Create VM from manifest", func() {
 				VM: testobjects.NewTestAlpineVM("vm-with-non-existent-pvc").WithNonMatchingDisk().Build(),
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot create a VM in different namespace", &testconfigs.CreateVMTestConfig{
+		Entry("cannot create a VM in different namespace", &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CreateVMFromManifestServiceAccountName,
+				ServiceAccount: CreateVMFromManifestServiceAccountNameNamespaced,
 				ExpectedLogs:   "cannot create resource \"virtualmachines\" in API group \"kubevirt.io\"",
-				LimitTestScope: NamespaceTestScope,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
 				VM:                testobjects.NewTestAlpineVM("different-ns-namespace-scope").Build(),
 				VMTargetNamespace: SystemTargetNS,
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot create a VM in different namespace in manifest", &testconfigs.CreateVMTestConfig{
+		Entry("cannot create a VM in different namespace in manifest", &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CreateVMFromManifestServiceAccountName,
+				ServiceAccount: CreateVMFromManifestServiceAccountNameNamespaced,
 				ExpectedLogs:   "cannot create resource \"virtualmachines\" in API group \"kubevirt.io\"",
-				LimitTestScope: NamespaceTestScope,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
 				VM:                        testobjects.NewTestAlpineVM("different-ns-namespace-scope-in-manifest").Build(),

--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -176,11 +176,10 @@ var _ = Describe("Create VM from template", func() {
 				},
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot create a VM in different namespace", &testconfigs.CreateVMTestConfig{
+		Entry("cannot create a VM in different namespace", &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CreateVMFromTemplateServiceAccountName,
-				ExpectedLogs:   "processedtemplates.template.openshift.io is forbidden",
-				LimitTestScope: NamespaceTestScope,
+				ServiceAccount: CreateVMFromTemplateServiceAccountNameNamespaced,
+				ExpectedLogs:   "cannot get resource \"templates\"",
 			},
 			TaskData: testconfigs.CreateVMTaskData{
 				Template: testtemplate.NewCirrosServerTinyTemplate().Build(),
@@ -190,11 +189,10 @@ var _ = Describe("Create VM from template", func() {
 				VMTargetNamespace: SystemTargetNS,
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot use template from a different namespace", &testconfigs.CreateVMTestConfig{
+		Entry("cannot use template from a different namespace", &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CreateVMFromTemplateServiceAccountName,
+				ServiceAccount: CreateVMFromTemplateServiceAccountNameNamespaced,
 				ExpectedLogs:   "templates.template.openshift.io \"unreachable-template\" is forbidden",
-				LimitTestScope: NamespaceTestScope,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
 				TemplateTargetNamespace: SystemTargetNS,
@@ -301,10 +299,9 @@ var _ = Describe("Create VM from template", func() {
 				},
 			},
 		}),
-		Entry("[CLUSTER SCOPED] works also in the same namespace as deploy", &testconfigs.CreateVMTestConfig{
+		Entry("works also in the same namespace as deploy", &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 				ServiceAccount: CreateVMFromTemplateServiceAccountName,
-				LimitTestScope: ClusterTestScope,
 				ExpectedLogs:   ExpectedSuccessfulVMCreation,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
@@ -312,7 +309,7 @@ var _ = Describe("Create VM from template", func() {
 				TemplateTargetNamespace: DeployTargetNS,
 				VMTargetNamespace:       DeployTargetNS,
 				TemplateParams: []string{
-					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("same-ns-cluster-scope")),
+					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("same-ns")),
 				},
 			},
 		}),

--- a/modules/tests/test/execute_and_cleanup_vm_test.go
+++ b/modules/tests/test/execute_and_cleanup_vm_test.go
@@ -278,11 +278,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 					Script: helloWorldScript,
 				},
 			}),
-			Entry("[NAMESPACE SCOPED] cannot execute command in different namespace", &testconfigs.ExecuteOrCleanupVMTestConfig{
-				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-					ServiceAccount: ExecuteInVMServiceAccountName,
-					LimitTestScope: NamespaceTestScope,
-				},
+			Entry("cannot execute command in different namespace", &testconfigs.ExecuteOrCleanupVMTestConfig{
 				TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
 					VM:                testobjects.NewTestFedoraCloudVM("execute-command-in-different-ns").WithCloudConfig(fedoraCloudConfig).Build(),
 					Secret:            testobjects.NewTestSecret(sshConnectionInfo),
@@ -330,12 +326,11 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 					CommandArgs: []string{"world", "!"},
 				},
 			}),
-			Entry("[CLUSTER SCOPED] execute command in the same namespace as deploy", &testconfigs.ExecuteOrCleanupVMTestConfig{
+			Entry("execute command in the same namespace as deploy", &testconfigs.ExecuteOrCleanupVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ExecuteInVMServiceAccountName,
 					ExpectedLogs:   "hello world",
 					ExpectSuccess:  true,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
 					VM:                testobjects.NewTestFedoraCloudVM("execute-command-in-same-ns").WithCloudConfig(fedoraCloudConfig).Build(),
@@ -471,7 +466,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		// negative cases
 		Entry("execute and stops vm with too low timeout", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectedLogs:   "command timed out",
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -488,7 +483,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 
 		Entry("starts and execute and stops vm with too low timeout", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectedLogs:   "command timed out",
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -504,7 +499,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		// positive cases
 		Entry("stop vm", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectSuccess:  true,
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -516,7 +511,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("stop non running vm", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectSuccess:  true,
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -527,7 +522,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("delete vm", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectSuccess:  true,
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -539,7 +534,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("stop and delete vm", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectSuccess:  true,
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{
@@ -552,7 +547,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("execute and stop and delete vm", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectedLogs:   "hello world",
 				ExpectSuccess:  true,
 			},
@@ -567,7 +562,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("execute and stops vm with timeout", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectedLogs:   "hello world",
 				ExpectSuccess:  true,
 			},
@@ -582,7 +577,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("execute and deletes vm with timeout", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectedLogs:   "hello world",
 				ExpectSuccess:  true,
 			},
@@ -597,7 +592,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 		}),
 		Entry("stops failed VMI", &testconfigs.ExecuteOrCleanupVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: CleanupVMClusterTaskName,
+				ServiceAccount: CleanupVMServiceAccountName,
 				ExpectSuccess:  true,
 			},
 			TaskData: testconfigs.ExecuteOrCleanupVMTaskData{

--- a/modules/tests/test/framework/framework.go
+++ b/modules/tests/test/framework/framework.go
@@ -40,7 +40,6 @@ type Framework struct {
 }
 
 type TestConfig interface {
-	GetLimitTestScope() constants.TestScope
 	GetLimitEnvScope() constants.EnvScope
 	Init(options *testoptions.TestOptions)
 }
@@ -70,7 +69,6 @@ func (f *Framework) OnBeforeTestSetup(callback func(config TestConfig)) *Framewo
 }
 
 func (f *Framework) TestSetup(config TestConfig) {
-	limitScope := config.GetLimitTestScope()
 	limitEnvScope := config.GetLimitEnvScope()
 
 	// check global env limit first
@@ -83,10 +81,6 @@ func (f *Framework) TestSetup(config TestConfig) {
 		Skip(fmt.Sprintf("runs only in %v", limitEnvScope))
 	}
 
-	// check test case test scope limit
-	if limitScope != "" && limitScope != f.TestScope {
-		Skip(fmt.Sprintf("runs only in %v scope", limitScope))
-	}
 	if f.onBeforeTestSetup != nil {
 		f.onBeforeTestSetup(config)
 	}

--- a/modules/tests/test/framework/testoptions/test-options.go
+++ b/modules/tests/test/framework/testoptions/test-options.go
@@ -3,7 +3,6 @@ package testoptions
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +15,6 @@ var deployNamespace string
 var testNamespace string
 var storageClass string
 var kubeConfigPath string
-var scope string
 var debug string
 var isOKD string
 var skipCreateVMFromManifestTests string
@@ -28,7 +26,6 @@ type TestOptions struct {
 	TestNamespace                 string
 	StorageClass                  string
 	KubeConfigPath                string
-	TestScope                     constants.TestScope
 	EnvScope                      constants.EnvScope
 	Debug                         bool
 	SkipCreateVMFromManifestTests bool
@@ -46,7 +43,6 @@ func init() {
 	flag.StringVar(&storageClass, "storage-class", "", "Storage class to be used for creating test DVs/PVCs")
 	flag.StringVar(&kubeConfigPath, "kubeconfig-path", "", "Path to the kubeconfig")
 	flag.StringVar(&isOKD, "is-okd", "", "Set to true if running on OKD. One of: true|false")
-	flag.StringVar(&scope, "scope", "", "Scope of the tests. One of: cluster|namespace")
 	flag.StringVar(&debug, "debug", "", "Debug keeps all the resources alive after the tests complete. One of: true|false")
 	flag.StringVar(&skipCreateVMFromManifestTests, "skip-create-vm-from-manifests-tests", "", "Skip create vm from manifests test suite. One of: true|false")
 	flag.StringVar(&skipExecuteInVMTests, "skip-execute-in-vm-tests", "", "Skip execute in vm test suite. One of: true|false")
@@ -62,14 +58,6 @@ func InitTestOptions(testOptions *TestOptions) error {
 
 	if testNamespace == "" {
 		return errors.New("--test-namespace must be specified")
-	}
-
-	if scope == "" {
-		testOptions.TestScope = constants.NamespaceTestScope
-	} else if constants.TestScope(scope) == constants.NamespaceTestScope || constants.TestScope(scope) == constants.ClusterTestScope {
-		testOptions.TestScope = constants.TestScope(scope)
-	} else {
-		return fmt.Errorf("invalid scope, only %v or %v is allowed", constants.ClusterTestScope, constants.NamespaceTestScope)
 	}
 
 	if kubeConfigPath != "" {

--- a/modules/tests/test/generate_ssh_keys_test.go
+++ b/modules/tests/test/generate_ssh_keys_test.go
@@ -82,20 +82,18 @@ var _ = Describe("Generate SSH Keys", func() {
 				AdditionalSSHKeygenOptions: "-3 unknown-param test",
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot create public secret in different namespace", &testconfigs.GenerateSshKeysTestConfig{
+		Entry("cannot create public secret in different namespace", &testconfigs.GenerateSshKeysTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: GenerateSshKeysServiceAccountName,
-				LimitTestScope: NamespaceTestScope,
+				ServiceAccount: GenerateSshKeysServiceAccountNameNamespaced,
 				ExpectedLogs:   "secrets is forbidden",
 			},
 			TaskData: testconfigs.GenerateSshKeysTaskData{
 				PublicKeySecretTargetNamespace: SystemTargetNS,
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot create private secret in different namespace", &testconfigs.GenerateSshKeysTestConfig{
+		Entry("cannot create private secret in different namespace", &testconfigs.GenerateSshKeysTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: GenerateSshKeysServiceAccountName,
-				LimitTestScope: NamespaceTestScope,
+				ServiceAccount: GenerateSshKeysServiceAccountNameNamespaced,
 				ExpectedLogs:   "secrets is forbidden",
 			},
 			TaskData: testconfigs.GenerateSshKeysTaskData{
@@ -209,11 +207,10 @@ var _ = Describe("Generate SSH Keys", func() {
 				},
 			},
 		}),
-		Entry("[CLUSTER SCOPED] works also in the same namespace as deploy", &testconfigs.GenerateSshKeysTestConfig{
+		Entry("works also in the same namespace as deploy", &testconfigs.GenerateSshKeysTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 				ServiceAccount: GenerateSshKeysServiceAccountName,
 				ExpectedLogs:   ExpectedGenerateSshKeysMessage,
-				LimitTestScope: ClusterTestScope,
 			},
 			TaskData: testconfigs.GenerateSshKeysTaskData{
 				PrivateKeySecretTargetNamespace: DeployTargetNS,

--- a/modules/tests/test/modify-vm-template_test.go
+++ b/modules/tests/test/modify-vm-template_test.go
@@ -113,11 +113,10 @@ var _ = Describe("Modify template task", func() {
 					TemplateName: testtemplate.CirrosTemplateName,
 				},
 			}),
-			Entry("[NAMESPACE SCOPED] cannot updated template in different namespace", &testconfigs.ModifyTemplateTestConfig{
+			Entry("cannot updated template in different namespace", &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-					ServiceAccount: ModifyTemplateServiceAccountName,
+					ServiceAccount: ModifyTemplateServiceAccountNameNamespaced,
 					ExpectedLogs:   "cannot get resource \"templates\" in API group \"template.openshift.io\"",
-					LimitTestScope: NamespaceTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					TemplateName:            testtemplate.CirrosTemplateName,
@@ -331,7 +330,6 @@ var _ = Describe("Modify template task", func() {
 			Entry("should update template across namespaces", &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                testtemplate.NewCirrosServerTinyTemplate().Build(),
@@ -368,7 +366,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                 testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -415,7 +412,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                 testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -457,7 +453,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -514,7 +509,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -558,7 +552,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -602,7 +595,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                 testtemplate.NewRhelDesktopTinyTemplate().Build(),
@@ -643,7 +635,6 @@ var _ = Describe("Modify template task", func() {
 			config := &testconfigs.ModifyTemplateTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyTemplateServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 				},
 				TaskData: testconfigs.ModifyTemplateTaskData{
 					Template:                testtemplate.NewRhelDesktopTinyTemplate().Build(),

--- a/modules/tests/test/modify_data_object_test.go
+++ b/modules/tests/test/modify_data_object_test.go
@@ -69,11 +69,9 @@ var _ = Describe("Modify data objects", func() {
 					DataVolume: datavolume.NewBlankDataVolume("").Build(),
 				},
 			}),
-			Entry("[NAMESPACE SCOPED] cannot create a DataVolume in different namespace", &testconfigs.ModifyDataObjectTestConfig{
+			Entry("cannot create a DataVolume in different namespace", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-					ServiceAccount: ModifyDataObjectServiceAccountName,
-					LimitTestScope: NamespaceTestScope,
-					ExpectedLogs:   "datavolumes.cdi.kubevirt.io is forbidden",
+					ExpectedLogs: "datavolumes.cdi.kubevirt.io is forbidden",
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
 					DataVolume: datavolume.NewBlankDataVolume("different-ns-namespace-scope").Build(),
@@ -119,14 +117,13 @@ var _ = Describe("Modify data objects", func() {
 					WaitForSuccess: true,
 				},
 			}),
-			Entry("[CLUSTER SCOPED] works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{
+			Entry("works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyDataObjectServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 					Timeout:        Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataVolume:     datavolume.NewBlankDataVolume("same-ns-cluster-scope").Build(),
+					DataVolume:     datavolume.NewBlankDataVolume("same-ns").Build(),
 					WaitForSuccess: true,
 					Namespace:      DeployTargetNS,
 				},
@@ -369,10 +366,9 @@ var _ = Describe("Modify data objects", func() {
 					DataSource: datasource.NewDataSource("").Build(),
 				},
 			}),
-			Entry("[NAMESPACE SCOPED] cannot create a DataSource in different namespace", &testconfigs.ModifyDataObjectTestConfig{
+			Entry("cannot create a DataSource in different namespace", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-					ServiceAccount: ModifyDataObjectServiceAccountName,
-					LimitTestScope: NamespaceTestScope,
+					ServiceAccount: ModifyDataObjectServiceAccountNameNamespaced,
 					ExpectedLogs:   "datasources.cdi.kubevirt.io is forbidden",
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
@@ -433,14 +429,13 @@ var _ = Describe("Modify data objects", func() {
 					WaitForSuccess: true,
 				},
 			}),
-			Entry("[CLUSTER SCOPED] works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{
+			Entry("works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ServiceAccount: ModifyDataObjectServiceAccountName,
-					LimitTestScope: ClusterTestScope,
 					Timeout:        Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataSource:     datasource.NewDataSource("same-ns-cluster-scope").Build(),
+					DataSource:     datasource.NewDataSource("same-ns").Build(),
 					WaitForSuccess: true,
 					Namespace:      DeployTargetNS,
 				},

--- a/modules/tests/test/pipelines_test.go
+++ b/modules/tests/test/pipelines_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Pipelines tests", func() {
 						{
 							Name: "create-dv",
 							TaskRef: &v1beta1.TaskRef{
-								Kind: v1beta1.ClusterTaskKind,
+								Kind: v1beta1.NamespacedTaskKind,
 								Name: "modify-data-object",
 							},
 							Params: []v1beta1.Param{
@@ -70,7 +70,7 @@ spec:
 						}, {
 							Name: "sysprep-dv",
 							TaskRef: &v1beta1.TaskRef{
-								Kind: v1beta1.ClusterTaskKind,
+								Kind: v1beta1.NamespacedTaskKind,
 								Name: "disk-virt-sysprep",
 							},
 							Params: []v1beta1.Param{
@@ -92,7 +92,7 @@ spec:
 						}, {
 							Name: "create-updated-dv",
 							TaskRef: &v1beta1.TaskRef{
-								Kind: v1beta1.ClusterTaskKind,
+								Kind: v1beta1.NamespacedTaskKind,
 								Name: "modify-data-object",
 							},
 							Params: []v1beta1.Param{

--- a/modules/tests/test/testconfigs/copy-template-config.go
+++ b/modules/tests/test/testconfigs/copy-template-config.go
@@ -91,8 +91,8 @@ func (c *CopyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
-				Name: CopyTemplateClusterTaskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Name: CopyTemplateTaskName,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: c.ServiceAccount,

--- a/modules/tests/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
+++ b/modules/tests/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
@@ -87,7 +87,7 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *v1
 				StringVal: c.TaskData.Commands,
 			},
 		})
-		taskName = DiskVirtSysprepClusterTaskName
+		taskName = DiskVirtSysprepTaskName
 	} else {
 		params = append(params, v1beta1.Param{
 			Name: DiskVirtLibguestfsTasksParams.CustomizeCommands,
@@ -96,7 +96,7 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *v1
 				StringVal: c.TaskData.Commands,
 			},
 		})
-		taskName = DiskVirtCustomizeClusterTaskName
+		taskName = DiskVirtCustomizeTaskName
 	}
 
 	return &v1beta1.TaskRun{
@@ -107,7 +107,7 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *v1
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
 				Name: taskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout: &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			Params:  params,

--- a/modules/tests/test/testconfigs/execute-in-vm-test-config.go
+++ b/modules/tests/test/testconfigs/execute-in-vm-test-config.go
@@ -129,7 +129,7 @@ func (c *ExecuteOrCleanupVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 	}
 
 	if c.TaskData.ExecInVMMode == CleanupVMMode {
-		taskName = CleanupVMClusterTaskName
+		taskName = CleanupVMTaskName
 		if c.ServiceAccount != "" {
 			serviceAccountName = CleanupVMServiceAccountName
 		}
@@ -160,7 +160,7 @@ func (c *ExecuteOrCleanupVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 				})
 		}
 	} else {
-		taskName = ExecuteInVMClusterTaskName
+		taskName = ExecuteInVMTaskName
 		if c.ServiceAccount != "" {
 			serviceAccountName = ExecuteInVMServiceAccountName
 		}
@@ -174,7 +174,7 @@ func (c *ExecuteOrCleanupVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
 				Name: taskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: serviceAccountName,

--- a/modules/tests/test/testconfigs/generate-ssh-keys-test-config.go
+++ b/modules/tests/test/testconfigs/generate-ssh-keys-test-config.go
@@ -115,8 +115,8 @@ func (c *GenerateSshKeysTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
-				Name: GenerateSshKeysClusterTaskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Name: GenerateSshKeysTaskName,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: c.ServiceAccount,

--- a/modules/tests/test/testconfigs/modify-data-object-test-config.go
+++ b/modules/tests/test/testconfigs/modify-data-object-test-config.go
@@ -113,8 +113,8 @@ func (c *ModifyDataObjectTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
-				Name: ModifyDataObjectClusterTaskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Name: ModifyDataObjectTaskName,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: c.ServiceAccount,

--- a/modules/tests/test/testconfigs/modify-vm-template-test-config.go
+++ b/modules/tests/test/testconfigs/modify-vm-template-test-config.go
@@ -212,8 +212,8 @@ func (m *ModifyTemplateTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
-				Name: ModifyTemplateClusterTaskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Name: ModifyTemplateTaskName,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: m.GetTaskRunTimeout()},
 			ServiceAccountName: m.ServiceAccount,

--- a/modules/tests/test/testconfigs/test-config.go
+++ b/modules/tests/test/testconfigs/test-config.go
@@ -18,7 +18,6 @@ type PipelineRunExpectedTermination struct {
 type TaskRunTestConfig struct {
 	ServiceAccount      string
 	Timeout             *metav1.Duration
-	LimitTestScope      constants.TestScope
 	LimitEnvScope       constants.EnvScope
 	ExpectSuccess       bool
 	ExpectedLogs        string
@@ -31,10 +30,6 @@ func (t *TaskRunTestConfig) GetTaskRunTimeout() time.Duration {
 		return t.Timeout.Duration
 	}
 	return constants.Timeouts.DefaultTaskRun.Duration
-}
-
-func (t *TaskRunTestConfig) GetLimitTestScope() constants.TestScope {
-	return t.LimitTestScope
 }
 
 func (t *TaskRunTestConfig) GetLimitEnvScope() constants.EnvScope {

--- a/modules/tests/test/testconfigs/vm-test-config.go
+++ b/modules/tests/test/testconfigs/vm-test-config.go
@@ -353,7 +353,7 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 
 	switch c.TaskData.CreateMode {
 	case CreateVMVMManifestMode:
-		taskName = CreateVMFromManifestClusterTaskName
+		taskName = CreateVMFromManifestTaskName
 		taskRunName = "taskrun-vm-create-from-manifest"
 
 		params = append(params,
@@ -373,7 +373,7 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 			},
 		)
 	case CreateVMTemplateMode:
-		taskName = CreateVMFromTemplateClusterTaskName
+		taskName = CreateVMFromTemplateTaskName
 		taskRunName = "taskrun-vm-create-from-template"
 
 		var templateNamespace string
@@ -426,7 +426,7 @@ func (c *CreateVMTestConfig) GetTaskRun() *v1beta1.TaskRun {
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
 				Name: taskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: c.ServiceAccount,

--- a/modules/tests/test/testconfigs/wait-for-vmi-status-test-config.go
+++ b/modules/tests/test/testconfigs/wait-for-vmi-status-test-config.go
@@ -49,13 +49,13 @@ func (c *WaitForVMIStatusTestConfig) Init(options *testoptions.TestOptions) {
 func (c *WaitForVMIStatusTestConfig) GetTaskRun() *v1beta1.TaskRun {
 	return &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      E2ETestsRandomName("taskrun-" + WaitForVMIStatusClusterTaskName),
+			Name:      E2ETestsRandomName("taskrun-" + WaitForVMIStatusTaskName),
 			Namespace: c.deploymentNamespace,
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
-				Name: WaitForVMIStatusClusterTaskName,
-				Kind: v1beta1.ClusterTaskKind,
+				Name: WaitForVMIStatusTaskName,
+				Kind: v1beta1.NamespacedTaskKind,
 			},
 			Timeout:            &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			ServiceAccountName: c.ServiceAccount,

--- a/modules/tests/test/wait_for_vmi_status_test.go
+++ b/modules/tests/test/wait_for_vmi_status_test.go
@@ -79,10 +79,9 @@ var _ = Describe("Wait for VMI Status", func() {
 				FailureCondition: "invalid#$%^$&",
 			},
 		}),
-		Entry("[NAMESPACE SCOPED] cannot check status for VMI in different namespace", &testconfigs.WaitForVMIStatusTestConfig{
+		Entry("cannot check status for VMI in different namespace", &testconfigs.WaitForVMIStatusTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
-				ServiceAccount: constants.WaitForVMIStatusServiceAccountName,
-				LimitTestScope: constants.NamespaceTestScope,
+				ServiceAccount: constants.WaitForVMIStatusServiceAccountNameNamespaced,
 				ExpectedLogs:   "cannot list resource \"virtualmachineinstances\" in API group \"kubevirt.io\"",
 				Timeout:        &metav1.Duration{1 * time.Minute},
 			},
@@ -140,11 +139,10 @@ var _ = Describe("Wait for VMI Status", func() {
 				ShouldStartVM:    true,
 			},
 		}),
-		Entry("[CLUSTER SCOPED] fulfills success condition in the same namespace as deploy", &testconfigs.WaitForVMIStatusTestConfig{
+		Entry("fulfills success condition in the same namespace as deploy", &testconfigs.WaitForVMIStatusTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 				ServiceAccount: constants.WaitForVMIStatusServiceAccountName,
 				ExpectSuccess:  true,
-				LimitTestScope: constants.ClusterTestScope,
 			},
 			TaskData: testconfigs.WaitForVMIStatusTaskData{
 				VM:                testobjects.NewTestAlpineVM("fulfills-success-condition-in-same-ns").Build(),

--- a/scripts/cluster-sync.sh
+++ b/scripts/cluster-sync.sh
@@ -7,7 +7,6 @@ REPO_DIR="$(realpath "${SCRIPT_DIR}/..")"
 
 source "${SCRIPT_DIR}/common.sh"
 
-export SCOPE="${SCOPE:-cluster}"
 export DEPLOY_NAMESPACE="${DEPLOY_NAMESPACE:-$(kubectl config view --minify --output 'jsonpath={..namespace}')}"
 IMAGE_REGISTRY=""
 IN_CLUSTER_IMAGE_REGISTRY=""

--- a/scripts/cluster-test.sh
+++ b/scripts/cluster-test.sh
@@ -8,7 +8,6 @@ source "${SCRIPT_DIR}/common.sh"
 
 RET_CODE=0
 
-SCOPE="${SCOPE:-cluster}"
 DEBUG="${DEBUG:-false}"
 STORAGE_CLASS="${STORAGE_CLASS:-}"
 NUM_NODES="${NUM_NODES:-2}"
@@ -17,28 +16,23 @@ ARTIFACT_DIR="${ARTIFACT_DIR:=dist}"
 ARTIFACT_DIR="$(readlink -m "${ARTIFACT_DIR}")"
 TEST_OUT="${ARTIFACT_DIR}/test.out"
 
-export JUNIT_FOLDER="$(pwd)/dist"
 
 rm -rf "${TEST_OUT}" "${ARTIFACT_DIR}/"junit*
+rm -rf "${ARTIFACT_DIR}"
+
 mkdir -p "${ARTIFACT_DIR}"
 
-if [[ "$SCOPE" == "cluster" ]]; then
-    export TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-tests-$(shuf -i10000-99999 -n1)}"
-else
-    export TEST_NAMESPACE="${TEST_NAMESPACE:-$DEPLOY_NAMESPACE}"
-fi
+export TEST_NAMESPACE="${TEST_NAMESPACE:-e2e-tests-$(shuf -i10000-99999 -n1)}"
 
 kubectl get namespaces -o name | grep -Eq "^namespace/$TEST_NAMESPACE$" || kubectl create namespace "$TEST_NAMESPACE" > /dev/null
 kubectl get namespaces -o name | grep -Eq "^namespace/$DEPLOY_NAMESPACE$" || kubectl create namespace "$DEPLOY_NAMESPACE" > /dev/null
 
 kubectl config set-context --current --namespace="$DEPLOY_NAMESPACE"
 
-mkdir $JUNIT_FOLDER
-
 pushd modules/tests || exit
   rm -rf dist
   mkdir dist
-  
+
   set +ex
   set -o pipefail
 
@@ -47,15 +41,13 @@ pushd modules/tests || exit
     --test-namespace="${TEST_NAMESPACE}" \
     --kubeconfig-path="${KUBECONFIG}" \
     --is-okd="${IS_OKD}" \
-    --ginkgo.junit-report="${JUNIT_FOLDER}/xunit_results.xml" \
-    --scope="${SCOPE}" \
+    --ginkgo.junit-report="${ARTIFACT_DIR}/xunit_results.xml" \
     --storage-class="${STORAGE_CLASS}" \
     --debug="${DEBUG}" | tee "${TEST_OUT}"
 
   RET_CODE="${PIPESTATUS[0]}"
   set -e
 
-  cp "${JUNIT_FOLDER}/xunit_results.xml" "${ARTIFACT_DIR}"
 popd
 
 exit "${RET_CODE}"

--- a/tasks/cleanup-vm/examples/taskruns/cleanup-vm-simple-taskrun.yaml
+++ b/tasks/cleanup-vm/examples/taskruns/cleanup-vm-simple-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: cleanup-vm-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: cleanup-vm
   params:
     - name: vmName

--- a/tasks/cleanup-vm/examples/taskruns/cleanup-vm-with-ssh-taskrun.yaml
+++ b/tasks/cleanup-vm/examples/taskruns/cleanup-vm-with-ssh-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: cleanup-vm-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: cleanup-vm
   params:
     - name: vmName

--- a/tasks/cleanup-vm/manifests/cleanup-vm.yaml
+++ b/tasks/cleanup-vm/manifests/cleanup-vm.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: cleanup-vm-task

--- a/tasks/copy-template/examples/taskruns/copy-template-taskrun.yaml
+++ b/tasks/copy-template/examples/taskruns/copy-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: copy-template-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: copy-template
   params:
   - name: sourceTemplateName

--- a/tasks/copy-template/manifests/copy-template.yaml
+++ b/tasks/copy-template/manifests/copy-template.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"

--- a/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun.yaml
+++ b/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: create-vm-from-manifest-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: create-vm-from-manifest
   params:
   - name: manifest

--- a/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: create-vm-from-manifest-task

--- a/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
+++ b/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: create-vm-from-template-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: create-vm-from-template
   params:
   - name: templateName

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: create-vm-from-template-task

--- a/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
+++ b/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
@@ -12,7 +12,7 @@ metadata:
   name: disk-virt-customize-taskrun-workspace
 spec:
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: disk-virt-customize
   params:
     - name: pvc

--- a/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun.yaml
+++ b/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun.yaml
@@ -5,7 +5,7 @@ metadata:
   name: disk-virt-customize-taskrun
 spec:
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: disk-virt-customize
   params:
     - name: pvc

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim

--- a/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
@@ -12,7 +12,7 @@ metadata:
   name: disk-virt-sysprep-taskrun-workspace
 spec:
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: disk-virt-sysprep
   params:
     - name: pvc

--- a/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun.yaml
+++ b/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun.yaml
@@ -5,7 +5,7 @@ metadata:
   name: disk-virt-sysprep-taskrun
 spec:
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: disk-virt-sysprep
   params:
     - name: pvc

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim

--- a/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun.yaml
+++ b/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: execute-in-vm-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: execute-in-vm
   params:
     - name: vmName

--- a/tasks/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/tasks/execute-in-vm/manifests/execute-in-vm.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: execute-in-vm-task

--- a/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun.yaml
+++ b/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: generate-ssh-keys-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: generate-ssh-keys
   params:
     - name: publicKeySecretName

--- a/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-simple-taskrun.yaml
+++ b/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-simple-taskrun.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   serviceAccountName: generate-ssh-keys-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: generate-ssh-keys
   params: []

--- a/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: generate-ssh-keys-task

--- a/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun.yaml
+++ b/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: modify-data-object-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: modify-data-object
   params:
     - name: waitForSuccess

--- a/tasks/modify-data-object/manifests/modify-data-object.yaml
+++ b/tasks/modify-data-object/manifests/modify-data-object.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-data-object-task

--- a/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun.yaml
+++ b/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: modify-vm-template-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: modify-vm-template
   params:
   - name: templateName

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"

--- a/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
+++ b/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
@@ -10,7 +10,7 @@ spec:
       runAsGroup: 1001
       fsGroup: 1001
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: modify-windows-iso-file
   params:
   - name: pvcName

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: modify-windows-iso-file-task

--- a/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun.yaml
+++ b/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: wait-for-vmi-status-task
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: wait-for-vmi-status
   params:
     - name: vmiName

--- a/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: wait-for-vmi-status-task

--- a/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
+++ b/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: vmName

--- a/templates/copy-template/examples/copy-template-taskrun.yaml
+++ b/templates/copy-template/examples/copy-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
   - name: sourceTemplateName

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"

--- a/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
+++ b/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
   - name: manifest

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}

--- a/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
+++ b/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
   - name: templateName

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
@@ -15,7 +15,7 @@ spec:
   serviceAccountName: {{ sa_name }}
 {% endif %}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: pvc

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
@@ -8,7 +8,7 @@ spec:
   serviceAccountName: {{ sa_name }}
 {% endif %}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: pvc

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
@@ -15,7 +15,7 @@ spec:
   serviceAccountName: {{ sa_name }}
 {% endif %}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: pvc

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
@@ -8,7 +8,7 @@ spec:
   serviceAccountName: {{ sa_name }}
 {% endif %}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: pvc

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     pvc.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}

--- a/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
+++ b/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: vmName

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}

--- a/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
+++ b/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
 {% if item.type == "advanced" %}
   params:

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}

--- a/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
+++ b/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: waitForSuccess

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}

--- a/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
+++ b/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
   - name: templateName

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"

--- a/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
+++ b/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
@@ -10,7 +10,7 @@ spec:
       runAsGroup: 1001
       fsGroup: 1001
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
   - name: pvcName

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}

--- a/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
+++ b/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   serviceAccountName: {{ sa_name }}
   taskRef:
-    kind: ClusterTask
+    kind: Task
     name: {{ task_name }}
   params:
     - name: vmiName

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: tekton.dev/v1beta1
-kind: ClusterTask
+kind: Task
 metadata:
   annotations:
     task.kubevirt.io/associatedServiceAccount: {{ sa_name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: replace clusterTask with tasks

clusterTasks are deprecated
https://tekton.dev/docs/pipelines/tasks/#task-vs-clustertask.
This PR changes all clusterTasks to tasks and do all necessary
modifications (update manifests, e2e tests, example pipelines, ...).

**Release note**:
```
feat: Replace cluster tasks with task object
```
