### PR TITLE
fix: fix wrong URL for disk-virt tasks

### DIFF
--- a/configs/disk-virt-customize.yaml
+++ b/configs/disk-virt-customize.yaml
@@ -1,3 +1,3 @@
 task_name: disk-virt-customize
 task_category: disk-virt-customize
-main_image: quay.io/kubevirt/tekton-task-disk-virt
+main_image: quay.io/kubevirt/tekton-tasks-disk-virt

--- a/configs/disk-virt-sysprep.yaml
+++ b/configs/disk-virt-sysprep.yaml
@@ -1,3 +1,3 @@
 task_name: disk-virt-sysprep
 task_category: disk-virt-sysprep
-main_image: quay.io/kubevirt/tekton-task-disk-virt
+main_image: quay.io/kubevirt/tekton-tasks-disk-virt

--- a/configs/modify-windows-iso-file.yaml
+++ b/configs/modify-windows-iso-file.yaml
@@ -1,5 +1,5 @@
 task_name: modify-windows-iso-file
 task_category: modify-windows-iso-file
-extract_iso_image: quay.io/kubevirt/tekton-task-disk-virt
+extract_iso_image: quay.io/kubevirt/tekton-tasks-disk-virt
 modify_iso_image: quay.io/kubevirt/tekton-tasks
 create_iso_image: quay.io/kubevirt/tekton-tasks

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -291,7 +291,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-customize
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:
@@ -419,7 +419,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-sysprep
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:
@@ -873,7 +873,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x
@@ -945,7 +945,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -540,7 +540,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-customize
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:
@@ -668,7 +668,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-sysprep
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:
@@ -1307,7 +1307,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x
@@ -1379,7 +1379,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -30,7 +30,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-customize
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -30,7 +30,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-sysprep
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       command:
         - entrypoint
       args:

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -21,7 +21,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x
@@ -93,7 +93,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-task-disk-virt:v0.14.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.14.0"
       script: |
         #!/bin/bash
         set -x


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix wrong URL for disk-virt tasks

This commit fixes wrong URL for disk-virt tasks (quay.io/kubevirt/tekton-tasks-disk-virt).
Regenerate deploy manifests

**Release note**:
```
NONE
```
