### PR TITLE
chore: increase timeout for taskRun tests

### DIFF
--- a/modules/tests/test/constants/timeout.go
+++ b/modules/tests/test/constants/timeout.go
@@ -19,7 +19,7 @@ type timeouts struct {
 
 var Timeouts = timeouts{
 	Zero:                      &metav1.Duration{0 * time.Second},
-	TaskRunExtraWaitDelay:     &metav1.Duration{80 * time.Second},
+	TaskRunExtraWaitDelay:     &metav1.Duration{5 * time.Minute},
 	SmallDVCreation:           &metav1.Duration{15 * time.Minute},
 	QuickTaskRun:              &metav1.Duration{5 * time.Minute},
 	DefaultTaskRun:            &metav1.Duration{10 * time.Minute},

--- a/modules/tests/test/tekton/taskrun.go
+++ b/modules/tests/test/tekton/taskrun.go
@@ -23,9 +23,10 @@ import (
 func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeout time.Duration, inState tkntest.ConditionAccessorFn) (*v1beta1.TaskRun, string) {
 	isCapturing := false
 	logs := make(chan string, 1)
-
+	var taskRun *v1beta1.TaskRun
 	err := wait.PollImmediate(constants.PollInterval, timeout, func() (bool, error) {
-		taskRun, err := clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		var err error
+		taskRun, err = clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -50,9 +51,9 @@ func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeo
 		}
 		return inState(&taskRun.Status)
 	})
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	taskRun, err := clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		fmt.Printf("%#v \n", taskRun)
+	}
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 	if isCapturing {


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: increase timeout for taskRun tests
add debug line, which will print taskRun in stdout in case of timeout

**Release note**:
```
NONE
```
