### PR TITLE
[release-v0.13] chore: debug wait-for-vmi and execute-in-vm tests

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -6,8 +6,7 @@ if kubectl get namespace tekton-pipelines > /dev/null 2>&1; then
   exit 0
 fi
 
-KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+KUBEVIRT_VERSION="v0.59.1"
 
 CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')

--- a/modules/tests/test/disk_virt_libguestfs_tasks_test.go
+++ b/modules/tests/test/disk_virt_libguestfs_tasks_test.go
@@ -42,10 +42,19 @@ var _ = Describe("Run disk virt-customize / virt-sysprep", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 
-			runner.NewTaskRunRunner(f, config.GetTaskRun()).
+			r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 				CreateTaskRun().
-				ExpectFailure().
-				ExpectLogs(config.GetAllExpectedLogs()...).
+				ExpectFailure()
+			// debug lines, which should help to debug flaky tests
+			err := r.GetError()
+			if err != nil {
+				r.PrintTektonInfo()
+				if dv := config.TaskData.Datavolume; dv != nil {
+					r.PrintDatavolumeInfo(config.TaskData.Datavolume.Namespace, config.TaskData.Datavolume.Name)
+				}
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+			r.ExpectLogs(config.GetAllExpectedLogs()...).
 				ExpectResults(nil)
 		},
 			Entry("no pvc", &testconfigs.DiskVirtLibguestfsTestConfig{

--- a/modules/tests/test/execute_and_cleanup_vm_test.go
+++ b/modules/tests/test/execute_and_cleanup_vm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/framework"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/runner"
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/testconfigs"
+	vmhelper "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/vm"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -93,14 +94,30 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 				if config.TaskData.ShouldStartVM {
 					err := f.KubevirtClient.VirtualMachine(vm.Namespace).Start(vm.Name, &kubevirtv1.StartOptions{})
 					Expect(err).ShouldNot(HaveOccurred())
-					time.Sleep(Timeouts.WaitBeforeExecutingVM.Duration)
+
+					vm, err := vmhelper.WaitForVM(f.KubevirtClient, vm.Namespace, vm.Name,
+						kubevirtv1.Running, config.GetTaskRunTimeout(), false)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Expect(*vm.Spec.Running).To(BeTrue(), "vm should be running")
 				}
 			}
 
-			runner.NewTaskRunRunner(f, config.GetTaskRun()).
+			r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 				CreateTaskRun().
-				ExpectSuccessOrFailure(config.ExpectSuccess).
-				ExpectLogs(config.GetAllExpectedLogs()...).
+				ExpectSuccessOrFailure(config.ExpectSuccess)
+
+			// debug lines, which should help to debug flaky tests
+			err := r.GetError()
+			if err != nil {
+				r.PrintTektonInfo()
+				if vm := config.TaskData.VM; vm != nil {
+					r.PrintVMInfo(vm.Namespace, vm.Name)
+				}
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			r.ExpectLogs(config.GetAllExpectedLogs()...).
 				ExpectTermination(config.ExpectedTermination).
 				ExpectResults(nil)
 		},
@@ -452,10 +469,21 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 			}
 		}
 
-		runner.NewTaskRunRunner(f, config.GetTaskRun()).
+		r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 			CreateTaskRun().
-			ExpectSuccessOrFailure(config.ExpectSuccess).
-			ExpectLogs(config.GetAllExpectedLogs()...).
+			ExpectSuccessOrFailure(config.ExpectSuccess)
+
+		// debug lines, which should help to debug flaky tests
+		err := r.GetError()
+		if err != nil {
+			r.PrintTektonInfo()
+			if vm := config.TaskData.VM; vm != nil {
+				r.PrintVMInfo(vm.Namespace, vm.Name)
+			}
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		r.ExpectLogs(config.GetAllExpectedLogs()...).
 			ExpectTermination(config.ExpectedTermination).
 			ExpectResults(nil)
 

--- a/modules/tests/test/tekton/taskrun.go
+++ b/modules/tests/test/tekton/taskrun.go
@@ -20,12 +20,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeout time.Duration, inState tkntest.ConditionAccessorFn) (*v1beta1.TaskRun, string) {
+func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeout time.Duration, inState tkntest.ConditionAccessorFn) (*v1beta1.TaskRun, string, *v1.Pod, error) {
 	isCapturing := false
 	logs := make(chan string, 1)
-
+	var taskRun *v1beta1.TaskRun
 	err := wait.PollImmediate(constants.PollInterval, timeout, func() (bool, error) {
-		taskRun, err := clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		var err error
+		taskRun, err = clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
 		}
@@ -50,16 +51,18 @@ func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeo
 		}
 		return inState(&taskRun.Status)
 	})
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	if err != nil {
+		pod, podErr := clients.CoreV1Client.Pods(taskRun.Namespace).Get(context.Background(), taskRun.Status.PodName, metav1.GetOptions{})
+		gomega.Expect(podErr).ShouldNot(gomega.HaveOccurred())
 
-	taskRun, err := clients.TknClient.TaskRuns(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-
-	if isCapturing {
-		return taskRun, <-logs
+		return taskRun, <-logs, pod, err
 	}
 
-	return taskRun, ""
+	if isCapturing {
+		return taskRun, <-logs, nil, nil
+	}
+
+	return taskRun, "", nil, nil
 }
 
 func PrintTaskRunDebugInfo(clients *clients.Clients, taskRunNamespace, taskRunName string) {

--- a/modules/tests/test/wait_for_vmi_status_test.go
+++ b/modules/tests/test/wait_for_vmi_status_test.go
@@ -30,10 +30,21 @@ var _ = Describe("Wait for VMI Status", func() {
 			}
 		}
 
-		runner.NewTaskRunRunner(f, config.GetTaskRun()).
+		r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 			CreateTaskRun().
-			ExpectSuccessOrFailure(config.ExpectSuccess).
-			ExpectLogs(config.GetAllExpectedLogs()...).
+			ExpectSuccessOrFailure(config.ExpectSuccess)
+
+		// debug lines, which should help to debug flaky tests
+		err := r.GetError()
+		if err != nil {
+			r.PrintTektonInfo()
+			if vm := config.TaskData.VM; vm != nil {
+				r.PrintVMInfo(vm.Namespace, vm.Name)
+			}
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		r.ExpectLogs(config.GetAllExpectedLogs()...).
 			ExpectTermination(config.ExpectedTermination).
 			ExpectResults(nil)
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: debug wait-for-vmi and execute-in-vm tests

This PR updates behaviour of WaitForTaskRunState function, which will
not fail after timeout, but instead it saves error to struct which can be then
recognized and run some after code (in this case print out status of VM)
**Release note**:
```
NONE
```
