### PR TITLE
chore: debug wait-for-vmi, disk-virt and execute-in-vm tests

### DIFF
--- a/modules/tests/test/create_vm_from_manifest_test.go
+++ b/modules/tests/test/create_vm_from_manifest_test.go
@@ -232,7 +232,9 @@ var _ = Describe("Create VM from manifest", func() {
 		expectedVM := config.TaskData.VM
 		// fill VM accordingly
 		expectedVM.Spec.Template.Spec.Domain.Machine = vm.Spec.Template.Spec.Domain.Machine // ignore Machine
-
+		fmt.Printf("#%v \n", vm.Spec.Template.Spec)
+		fmt.Println("------------------------------------------")
+		fmt.Printf("#%v \n", expectedVM.Spec.Template.Spec)
 		Expect(vm.Spec.Template.Spec).Should(Equal(expectedVM.Spec.Template.Spec))
 		// check VM labels
 		Expect(vm.Labels).Should(Equal(expectedVM.Labels))

--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	testtemplate "github.com/kubevirt/kubevirt-tekton-tasks/modules/sharedtest/testobjects/template"
 	. "github.com/kubevirt/kubevirt-tekton-tasks/modules/tests/test/constants"
@@ -295,7 +296,7 @@ var _ = Describe("Create VM from template", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
-	It("VM is created from template properly", func() {
+	FIt("VM is created from template properly", func() {
 		template := testtemplate.NewCirrosServerTinyTemplate().Build()
 		config := &testconfigs.CreateVMTestConfig{
 			TaskRunTestConfig: testconfigs.TaskRunTestConfig{
@@ -336,6 +337,9 @@ var _ = Describe("Create VM from template", func() {
 		expectedVM.Spec.Template.Spec.Hostname = vmName
 		expectedVM.Spec.Template.Spec.Domain.Machine = vm.Spec.Template.Spec.Domain.Machine // ignore Machine
 
+		fmt.Printf("#%v \n", vm.Spec.Template.Spec)
+		fmt.Println("------------------------------------------")
+		fmt.Printf("#%v \n", expectedVM.Spec.Template.Spec)
 		Expect(vm.Spec.Template.Spec).Should(Equal(expectedVM.Spec.Template.Spec))
 		// check VM labels
 		Expect(vm.Labels).Should(Equal(map[string]string{

--- a/modules/tests/test/disk_virt_libguestfs_tasks_test.go
+++ b/modules/tests/test/disk_virt_libguestfs_tasks_test.go
@@ -42,10 +42,19 @@ var _ = Describe("Run disk virt-customize / virt-sysprep", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 
-			runner.NewTaskRunRunner(f, config.GetTaskRun()).
+			r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 				CreateTaskRun().
-				ExpectFailure().
-				ExpectLogs(config.GetAllExpectedLogs()...).
+				ExpectFailure()
+			// debug lines, which should help to debug flaky tests
+			err := r.GetError()
+			if err != nil {
+				r.PrintTektonInfo()
+				if dv := config.TaskData.Datavolume; dv != nil {
+					r.PrintDatavolumeInfo(config.TaskData.Datavolume.Namespace, config.TaskData.Datavolume.Name)
+				}
+				Fail("error should not have occured")
+			}
+			r.ExpectLogs(config.GetAllExpectedLogs()...).
 				ExpectResults(nil)
 		},
 			Entry("no pvc", &testconfigs.DiskVirtLibguestfsTestConfig{

--- a/modules/tests/test/wait_for_vmi_status_test.go
+++ b/modules/tests/test/wait_for_vmi_status_test.go
@@ -30,10 +30,21 @@ var _ = Describe("Wait for VMI Status", func() {
 			}
 		}
 
-		runner.NewTaskRunRunner(f, config.GetTaskRun()).
+		r := runner.NewTaskRunRunner(f, config.GetTaskRun()).
 			CreateTaskRun().
-			ExpectSuccessOrFailure(config.ExpectSuccess).
-			ExpectLogs(config.GetAllExpectedLogs()...).
+			ExpectSuccessOrFailure(config.ExpectSuccess)
+
+		// debug lines, which should help to debug flaky tests
+		err := r.GetError()
+		if err != nil {
+			r.PrintTektonInfo()
+			if vm := config.TaskData.VM; vm != nil {
+				r.PrintVMInfo(vm.Namespace, vm.Name)
+			}
+			Fail("error should not have occured")
+		}
+
+		r.ExpectLogs(config.GetAllExpectedLogs()...).
 			ExpectTermination(config.ExpectedTermination).
 			ExpectResults(nil)
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates behaviour of WaitForTaskRunState function, which will not fail after timeout, but instead it saves error to struct which can be then recognized and run some after code (in this case print out status of VM)

**Release note**:
```
NONE
```
