### PR TITLE
fix: custom configuration of crio in testing cluster

### DIFF
--- a/automation/e2e-tests.sh
+++ b/automation/e2e-tests.sh
@@ -8,7 +8,7 @@ export DEPLOY_NAMESPACE="${DEPLOY_NAMESPACE:-e2e-tests-$(shuf -i10000-99999 -n1)
 export NUM_NODES=${NUM_NODES:-2}
 
 # See scripts/common.sh for IMAGE env variable names
-
+./automation/set-crio-permissions-command.sh
 ./automation/e2e-deploy-resources.sh
 
 kubectl get namespaces -o name | grep -Eq "^namespace/$DEPLOY_NAMESPACE$" || kubectl create namespace "$DEPLOY_NAMESPACE"

--- a/automation/set-crio-permissions-command.sh
+++ b/automation/set-crio-permissions-command.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -ex
+
+DEBUG_NS=debug-ns
+oc create ns ${DEBUG_NS}
+oc label ns ${DEBUG_NS} security.openshift.io/scc.podSecurityLabelSync=false --overwrite
+oc label ns ${DEBUG_NS} pod-security.kubernetes.io/enforce=privileged --overwrite
+
+NODES=$(oc get nodes -o json | jq -r .items[].metadata.name)
+
+while IFS= read -r node
+do
+	echo "setting device_ownership_from_security_context for ${node}.."
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host sed -i '/^\[crio\.runtime\]/a device_ownership_from_security_context = true' /etc/crio/crio.conf
+	echo "restarting crio service on ${node}"
+	oc debug node/${node} --to-namespace ${DEBUG_NS} -- chroot /host systemctl restart crio
+done <<< "${NODES}"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: custom configuration of crio in testing cluster

our e2e are not working due to permission issue in crio. cri-o/cri-o#7192 should revert the change. Until that revert PR is released and available in ci envs, we have to set special configuration on crio on all nodes

**Release note**:
```
NONE
```
