### PR TITLE
rbac: Audit `*` verbs

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -223,23 +223,13 @@ rules:
     resources:
       - virtualmachines/start
   - verbs:
-      - '*'
-    apiGroups:
-      - kubevirt.io
-    resources:
-      - virtualmachines/finalizers
-  - verbs:
-      - '*'
+      - update
+
     apiGroups:
       - ''
     resources:
       - persistentvolumeclaims
-  - verbs:
-      - '*'
-    apiGroups:
-      - cdi.kubevirt.io
-    resources:
-      - datavolumes
+
 
 ---
 apiVersion: v1
@@ -706,7 +696,10 @@ metadata:
   name: generate-ssh-keys-task
 rules:
   - verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - patch
     apiGroups:
       - ''
     resources:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -321,23 +321,13 @@ rules:
     resources:
       - virtualmachines/start
   - verbs:
-      - '*'
-    apiGroups:
-      - kubevirt.io
-    resources:
-      - virtualmachines/finalizers
-  - verbs:
-      - '*'
+      - update
+
     apiGroups:
       - ''
     resources:
       - persistentvolumeclaims
-  - verbs:
-      - '*'
-    apiGroups:
-      - cdi.kubevirt.io
-    resources:
-      - datavolumes
+
 
 ---
 apiVersion: v1
@@ -452,7 +442,7 @@ rules:
       - virtualmachines
       - virtualmachineinstances
   - verbs:
-      - '*'
+      - get
     apiGroups:
       - kubevirt.io
     resources:
@@ -472,13 +462,8 @@ rules:
     resources:
       - processedtemplates
   - verbs:
-      - '*'
-    apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-  - verbs:
-      - '*'
+      - create
+
     apiGroups:
       - cdi.kubevirt.io
     resources:
@@ -955,7 +940,10 @@ metadata:
   name: generate-ssh-keys-task
 rules:
   - verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - patch
     apiGroups:
       - ''
     resources:

--- a/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
@@ -91,23 +91,13 @@ rules:
     resources:
       - virtualmachines/start
   - verbs:
-      - '*'
-    apiGroups:
-      - kubevirt.io
-    resources:
-      - virtualmachines/finalizers
-  - verbs:
-      - '*'
+      - update
+
     apiGroups:
       - ''
     resources:
       - persistentvolumeclaims
-  - verbs:
-      - '*'
-    apiGroups:
-      - cdi.kubevirt.io
-    resources:
-      - datavolumes
+
 
 ---
 apiVersion: v1

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -93,7 +93,7 @@ rules:
       - virtualmachines
       - virtualmachineinstances
   - verbs:
-      - '*'
+      - get
     apiGroups:
       - kubevirt.io
     resources:
@@ -113,13 +113,8 @@ rules:
     resources:
       - processedtemplates
   - verbs:
-      - '*'
-    apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-  - verbs:
-      - '*'
+      - create
+
     apiGroups:
       - cdi.kubevirt.io
     resources:

--- a/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -79,7 +79,10 @@ metadata:
   name: generate-ssh-keys-task
 rules:
   - verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - patch
     apiGroups:
       - ''
     resources:

--- a/templates/create-vm-from-manifest/manifests/create-vm-from-manifest-role.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm-from-manifest-role.yaml
@@ -22,20 +22,10 @@ rules:
     resources:
       - virtualmachines/start
   - verbs:
-      - '*'
-    apiGroups:
-      - kubevirt.io
-    resources:
-      - virtualmachines/finalizers
-  - verbs:
-      - '*'
+      - update
+
     apiGroups:
       - ''
     resources:
       - persistentvolumeclaims
-  - verbs:
-      - '*'
-    apiGroups:
-      - cdi.kubevirt.io
-    resources:
-      - datavolumes
+

--- a/templates/create-vm-from-template/manifests/create-vm-from-template-role.yaml
+++ b/templates/create-vm-from-template/manifests/create-vm-from-template-role.yaml
@@ -16,7 +16,7 @@ rules:
       - virtualmachines
       - virtualmachineinstances
   - verbs:
-      - '*'
+      - get
     apiGroups:
       - kubevirt.io
     resources:
@@ -36,13 +36,8 @@ rules:
     resources:
       - processedtemplates
   - verbs:
-      - '*'
-    apiGroups:
-      - ''
-    resources:
-      - persistentvolumeclaims
-  - verbs:
-      - '*'
+      - create
+
     apiGroups:
       - cdi.kubevirt.io
     resources:

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys-role.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys-role.yaml
@@ -5,7 +5,10 @@ metadata:
   name: {{ role_name }}
 rules:
   - verbs:
-      - '*'
+      - get
+      - list
+      - create
+      - patch
     apiGroups:
       - ''
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
It replaces all `*` verbs by individual verbs required to run all intended operations. 

It drops the usage of `*` verbs, replacing them by individual verbs strictly required by the test suite, i.e. unit tests and functional tests. The auditing process has been split in the next action items:

* Deploying the operator in a CRC cluster and running the unit and function test.
* Deploying the operator in a 3 masters and 3 workers nodes and running the unit and functional tests.

jira-ticket: [CNV-24031](https://issues.redhat.com/browse/CNV-24031)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [https://bugzilla.redhat.com/show_bug.cgi?id=2223775](https://bugzilla.redhat.com/show_bug.cgi?id=2223775)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace the `*` verbs by individual verbs
```
