### PR TITLE
feat: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,47 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "all"
+    assignees:
+      - "ksimon1"
+      - "0xFelix"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.16"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    assignees:
+      - "ksimon1"
+      - "0xFelix"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.15"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    assignees:
+      - "ksimon1"
+      - "0xFelix"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "release-v0.13"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    assignees:
+      - "ksimon1"
+      - "0xFelix"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR adds configuration for dependabot for multiple branches, adds assignees to PRs and allow bumping of all dependencies (direct, indirect)
/cc @0xFelix 
**Release note**:
```
NONE
```
