### PR TITLE
fix: replace include with include_tasks

### DIFF
--- a/templates/cleanup-vm/generate-task.yaml
+++ b/templates/cleanup-vm/generate-task.yaml
@@ -14,7 +14,7 @@
     ssh_secret_name: "ssh-secret"
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ execute_in_vm_manifest_templates_dir }}/{{ task_category }}.yaml"
@@ -23,7 +23,7 @@
       vars:
         is_cleanup: true
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -62,4 +62,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/copy-template/generate-task.yaml
+++ b/templates/copy-template/generate-task.yaml
@@ -8,14 +8,14 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
         dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         mode: "{{ default_file_mode }}"
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -43,4 +43,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/create-vm-from-manifest/generate-task.yaml
+++ b/templates/create-vm-from-manifest/generate-task.yaml
@@ -8,14 +8,14 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_category }}.yaml"
         dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         mode: "{{ default_file_mode }}"
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -43,4 +43,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/create-vm-from-template/generate-task.yaml
+++ b/templates/create-vm-from-template/generate-task.yaml
@@ -10,14 +10,14 @@
     create_vm_from_manifest_manifest_templates_dir: ../create-vm-from-manifest/manifests
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ create_vm_from_manifest_manifest_templates_dir }}/{{ task_category }}.yaml"
         dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         mode: "{{ default_file_mode }}"
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -45,4 +45,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/disk-virt-customize/generate-task.yaml
+++ b/templates/disk-virt-customize/generate-task.yaml
@@ -8,7 +8,7 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
@@ -38,4 +38,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/disk-virt-sysprep/generate-task.yaml
+++ b/templates/disk-virt-sysprep/generate-task.yaml
@@ -8,7 +8,7 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
@@ -38,4 +38,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/execute-in-vm/generate-task.yaml
+++ b/templates/execute-in-vm/generate-task.yaml
@@ -11,7 +11,7 @@
     ssh_secret_name: "ssh-secret"
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
@@ -20,7 +20,7 @@
       vars:
         is_cleanup: false
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -58,4 +58,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/generate-ssh-keys/generate-task.yaml
+++ b/templates/generate-ssh-keys/generate-task.yaml
@@ -8,7 +8,7 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
@@ -17,7 +17,7 @@
       with_items:
         - { task_type: Default, task_with_flavor_name: "{{ task_name }}" }
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -46,4 +46,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/modify-data-object/generate-task.yaml
+++ b/templates/modify-data-object/generate-task.yaml
@@ -8,14 +8,14 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_category }}.yaml"
         dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         mode: "{{ default_file_mode }}"
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -43,4 +43,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/modify-vm-template/generate-task.yaml
+++ b/templates/modify-vm-template/generate-task.yaml
@@ -8,14 +8,14 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_category }}.yaml"
         dest: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         mode: "{{ default_file_mode }}"
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -43,4 +43,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/modify-windows-iso-file/generate-task.yaml
+++ b/templates/modify-windows-iso-file/generate-task.yaml
@@ -8,7 +8,7 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_category }}.yaml"
@@ -37,4 +37,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"

--- a/templates/wait-for-vmi-status/generate-task.yaml
+++ b/templates/wait-for-vmi-status/generate-task.yaml
@@ -8,7 +8,7 @@
     - ../../scripts/ansible/common.yaml
   tasks:
     - name: Init
-      include: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"
     - name: "Generate {{ task_name }} task"
       template:
         src: "{{ manifest_templates_dir }}/{{ task_name }}.yaml"
@@ -17,7 +17,7 @@
       with_items:
         - { task_type: Default, task_with_flavor_name: "{{ task_name }}" }
     - name: Generate roles
-      include: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/generate-roles.yaml"
       with_items:
         - { role_type: ClusterRole, prefix: zz- }
       vars:
@@ -45,4 +45,4 @@
         task_path: "{{ manifests_output_dir_tmp }}/{{ task_name }}.yaml"
         task_yaml: "{{ lookup('file', task_path) | from_yaml }}"
     - name: Assemble task
-      include: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"
+      include_tasks: "{{ repo_dir }}/scripts/ansible/assemble-task.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: replace include with include_tasks

ansible.builtin.include has been deprecated and removed from ansible-core. Because of that, release scripts are not working - https://github.com/kubevirt/kubevirt-tekton-tasks/actions/runs/7183095492/job/19561070924

**Release note**:
```
NONE
```
