### PR TITLE
feat: bump api version of task to v1 in manifests

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -131,7 +131,7 @@ subjects:
   - kind: ServiceAccount
     name: cleanup-vm-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -250,7 +250,7 @@ subjects:
   - kind: ServiceAccount
     name: create-vm-from-manifest-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -378,7 +378,7 @@ spec:
       optional: true
       mountPath: /data10
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -506,7 +506,7 @@ spec:
       optional: true
       mountPath: /data10
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -616,7 +616,7 @@ subjects:
   - kind: ServiceAccount
     name: execute-in-vm-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -724,7 +724,7 @@ subjects:
   - kind: ServiceAccount
     name: generate-ssh-keys-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -844,7 +844,7 @@ subjects:
   - kind: ServiceAccount
     name: modify-data-object-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -963,7 +963,7 @@ spec:
       emptyDir:
         sizeLimit: 12Gi
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -296,7 +296,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'
@@ -424,7 +424,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'
@@ -895,7 +895,7 @@ spec:
           value: "direct"
         - name: "HOME"
           value: "/usr/local/lib/guestfs/appliance"
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
         requests:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -540,7 +540,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'
@@ -668,7 +668,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'
@@ -1324,7 +1324,7 @@ spec:
           value: "direct"
         - name: "HOME"
           value: "/usr/local/lib/guestfs/appliance"
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
         requests:

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -131,7 +131,7 @@ subjects:
   - kind: ServiceAccount
     name: cleanup-vm-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -229,7 +229,7 @@ subjects:
   - kind: ServiceAccount
     name: copy-template-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -348,7 +348,7 @@ subjects:
   - kind: ServiceAccount
     name: create-vm-from-manifest-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -494,7 +494,7 @@ subjects:
   - kind: ServiceAccount
     name: create-vm-from-template-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -622,7 +622,7 @@ spec:
       optional: true
       mountPath: /data10
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -750,7 +750,7 @@ spec:
       optional: true
       mountPath: /data10
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -860,7 +860,7 @@ subjects:
   - kind: ServiceAccount
     name: execute-in-vm-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -968,7 +968,7 @@ subjects:
   - kind: ServiceAccount
     name: generate-ssh-keys-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -1088,7 +1088,7 @@ subjects:
   - kind: ServiceAccount
     name: modify-data-object-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -1273,7 +1273,7 @@ subjects:
   - kind: ServiceAccount
     name: modify-vm-template-task
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
@@ -1392,7 +1392,7 @@ spec:
       emptyDir:
         sizeLimit: 12Gi
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/cleanup-vm/manifests/cleanup-vm.yaml
+++ b/tasks/cleanup-vm/manifests/cleanup-vm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/copy-template/manifests/copy-template.yaml
+++ b/tasks/copy-template/manifests/copy-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/manifests/create-vm-from-manifest.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/manifests/create-vm-from-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -45,7 +45,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -45,7 +45,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'

--- a/tasks/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/tasks/execute-in-vm/manifests/execute-in-vm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/tasks/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/modify-data-object/manifests/modify-data-object.yaml
+++ b/tasks/modify-data-object/manifests/modify-data-object.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/manifests/modify-vm-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -50,7 +50,7 @@ spec:
           value: "direct"
         - name: "HOME"
           value: "/usr/local/lib/guestfs/appliance"
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
         requests:

--- a/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/tasks/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -45,7 +45,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -45,7 +45,7 @@ spec:
           value: $(params.additionalOptions)
         - name: LIBGUESTFS_BACKEND
           value: direct
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
           devices.kubevirt.io/tun: '1'

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -50,7 +50,7 @@ spec:
           value: "direct"
         - name: "HOME"
           value: "/usr/local/lib/guestfs/appliance"
-      resources:
+      computeResources:
         limits:
           devices.kubevirt.io/kvm: '1'
         requests:

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: bump api version of task to v1 in manifests

manifests were using v1beta api version. This commit changes it to v1.

**Release note**:
```
feat: bump api version of task to v1 in manifests
```
