### PR TITLE
feat: preparation for onboarding tasks to artifact hub

### DIFF
--- a/.github/workflows/artifact-hub-linter.yaml
+++ b/.github/workflows/artifact-hub-linter.yaml
@@ -1,0 +1,12 @@
+name: artifact hub linter
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: run ah linter
+      run: make run-ah-linter

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
           git rebase upstream/main
           git checkout -b update-tekton-tasks-manifests-${RELEASE_VERSION}
           sed -i "s/export RELEASE_VERSION.*=.*/export RELEASE_VERSION ?=${RELEASE_VERSION}/g" scripts/makefile-snippets/makefile-release.mk
-          make generate-yaml-tasks
+          make generate-yaml-tasks copy-released-manifests
           git add .
           git commit -sm "Update tekton tasks manifests to version ${RELEASE_VERSION}"
           git push --set-upstream origin update-tekton-tasks-manifests-${RELEASE_VERSION}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/dist/
 .idea/
+ah

--- a/configs/cleanup-vm.yaml
+++ b/configs/cleanup-vm.yaml
@@ -2,3 +2,4 @@ task_name: cleanup-vm
 task_category: execute-in-vm
 # execute-in-vm.yaml main_image should be also updated to match this one!
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: cleanup VM

--- a/configs/copy-template.yaml
+++ b/configs/copy-template.yaml
@@ -2,3 +2,4 @@ task_name: copy-template
 task_category: copy-template
 main_image: quay.io/kubevirt/tekton-tasks
 is_okd: true
+nice_name: copy template

--- a/configs/create-vm-from-manifest.yaml
+++ b/configs/create-vm-from-manifest.yaml
@@ -2,3 +2,4 @@ task_name: create-vm-from-manifest
 task_category: create-vm
 # create-vm-from-template.yaml main_image should be also updated to match this one!
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: create VM from manifest

--- a/configs/create-vm-from-template.yaml
+++ b/configs/create-vm-from-template.yaml
@@ -3,3 +3,4 @@ task_category: create-vm
 # create-vm-from-manifest.yaml main_image should be also updated to match this one!
 main_image: quay.io/kubevirt/tekton-tasks
 is_okd: true
+nice_name: create VM from template

--- a/configs/disk-virt-customize.yaml
+++ b/configs/disk-virt-customize.yaml
@@ -1,3 +1,4 @@
 task_name: disk-virt-customize
 task_category: disk-virt-customize
 main_image: quay.io/kubevirt/tekton-tasks-disk-virt
+nice_name: disk virt customize

--- a/configs/disk-virt-sysprep.yaml
+++ b/configs/disk-virt-sysprep.yaml
@@ -1,3 +1,4 @@
 task_name: disk-virt-sysprep
 task_category: disk-virt-sysprep
 main_image: quay.io/kubevirt/tekton-tasks-disk-virt
+nice_name: disk virt sysprep

--- a/configs/execute-in-vm.yaml
+++ b/configs/execute-in-vm.yaml
@@ -2,3 +2,4 @@ task_name: execute-in-vm
 task_category: execute-in-vm
 # cleanup-vm.yaml main_image should be also updated to match this one!
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: execute in vm

--- a/configs/generate-ssh-keys.yaml
+++ b/configs/generate-ssh-keys.yaml
@@ -1,3 +1,4 @@
 task_name: generate-ssh-keys
 task_category: generate-ssh-keys
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: generate ssh keys

--- a/configs/modify-data-object.yaml
+++ b/configs/modify-data-object.yaml
@@ -1,3 +1,4 @@
 task_name: modify-data-object
 task_category: modify-data-object
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: modify data object

--- a/configs/modify-object-task.yaml
+++ b/configs/modify-object-task.yaml
@@ -1,3 +1,0 @@
-task_name: modify-object
-task_category: modify-object
-main_image: quay.io/kubevirt/tekton-tasks

--- a/configs/modify-vm-template.yaml
+++ b/configs/modify-vm-template.yaml
@@ -2,3 +2,4 @@ task_name: modify-vm-template
 task_category: modify-vm-template
 main_image: quay.io/kubevirt/tekton-tasks
 is_okd: true
+nice_name: modify VM template

--- a/configs/modify-windows-iso-file.yaml
+++ b/configs/modify-windows-iso-file.yaml
@@ -3,3 +3,4 @@ task_category: modify-windows-iso-file
 extract_iso_image: quay.io/kubevirt/tekton-tasks-disk-virt
 modify_iso_image: quay.io/kubevirt/tekton-tasks
 create_iso_image: quay.io/kubevirt/tekton-tasks
+nice_name: modify Windows iso

--- a/configs/wait-for-vmi-status.yaml
+++ b/configs/wait-for-vmi-status.yaml
@@ -1,3 +1,4 @@
 task_name: wait-for-vmi-status
 task_category: wait-for-vmi-status
 main_image: quay.io/kubevirt/tekton-tasks
+nice_name: wait for VMI status

--- a/makefile
+++ b/makefile
@@ -56,6 +56,9 @@ push-release-images:
 copy-released-manifests:
 	./scripts/copy-released-manifests.sh
 
+run-ah-linter:
+	./scripts/run-ah-linter.sh
+
 release: generate-yaml-tasks build-release-images push-release-images
 
 vendor:
@@ -79,5 +82,6 @@ vendor:
 	release \
 	copy-released-manifests \
 	e2e-tests \
+	run-ah-linter \
 	onboard-new-task-with-ci-stub \
 	vendor

--- a/makefile
+++ b/makefile
@@ -53,6 +53,9 @@ build-release-images:
 push-release-images:
 	./scripts/push-release-images.sh
 
+copy-released-manifests:
+	./scripts/copy-released-manifests.sh
+
 release: generate-yaml-tasks build-release-images push-release-images
 
 vendor:
@@ -74,6 +77,7 @@ vendor:
 	cluster-clean \
 	cluster-clean-and-skip-images \
 	release \
+	copy-released-manifests \
 	e2e-tests \
 	onboard-new-task-with-ci-stub \
 	vendor

--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -3,17 +3,18 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
-    delete.params.task.kubevirt.io/type: boolean
-    stop.params.task.kubevirt.io/type: boolean
-    timeout.params.task.kubevirt.io/type: duration
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt cleanup VM"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: cleanup-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: cleanup-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
+    This task can stop and delete VMs
   params:
     - description: Name of a VM to execute the action in.
       name: vmName
@@ -90,24 +91,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/kind: VirtualMachine
-    manifest.params.task.kubevirt.io/apiVersion: kubevirt.io/v1
-    namespace.params.task.kubevirt.io/type: namespace
-    dataVolumes.params.task.kubevirt.io/kind: DataVolume
-    dataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    ownDataVolumes.params.task.kubevirt.io/kind: DataVolume
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    persistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    startVM.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt create VM from manifest"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: create-vm-from-manifest
-    task.kubevirt.io/category: create-vm
+    app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+    User can create VM from manifest or with the same parameters as for virtctl.
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
     - name: manifest
       description: YAML manifest of a VirtualMachine resource to be created.
@@ -157,15 +153,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    customizeCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt customize"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-customize
-    task.kubevirt.io/category: disk-virt-customize
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize
 spec:
+  description: >-
+    Run virt-customize command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-customize script in. PVC should be in the same namespace as taskrun/pipelinerun.
@@ -285,15 +283,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    sysprepCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt sysprep"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-sysprep
-    task.kubevirt.io/category: disk-virt-sysprep
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep
 spec:
+  description: >-
+    Run virt-sysprep command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-sysprep script in. PVC should be in the same namespace as taskrun/pipelinerun.
@@ -413,14 +413,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt execute in vm"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: execute-in-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: execute-in-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
   params:
     - description: Name of a VM to execute the action in.
       name: vmName
@@ -479,18 +482,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    publicKeySecretName.params.task.kubevirt.io/kind: Secret
-    publicKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    publicKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeySecretName.params.task.kubevirt.io/kind: Secret
-    privateKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    privateKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeyConnectionOptions.params.task.kubevirt.io/type: private-key-options-array
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt generate ssh keys"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: generate-ssh-keys
-    task.kubevirt.io/category: generate-ssh-keys
+    app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys
 spec:
+  description: >-
+    Generate SSH keys which can be used for KubeVirt virtual machines.
   params:
     - name: publicKeySecretName
       description: Name of a new or existing secret to append the generated public key to. The name will be generated and new secret created if not specified.
@@ -551,12 +553,13 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    waitForSuccess.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify data object"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-data-object
-    task.kubevirt.io/category: modify-data-object
+    app.kubernetes.io/version: v0.17.0
   name: modify-data-object
 spec:
   description: >-
@@ -621,11 +624,24 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify Windows iso"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-windows-iso-file
-    task.kubevirt.io/category: modify-windows-iso-file
+    app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file
 spec:
+  description: >-
+    This tasks is modifying windows iso file. It replaces prompt 
+    bootloader with non prompt one. This helps with automation of 
+    windows installation which requires EFI - the prompt bootloader will not 
+    continue with installation until some key is pressed. The non prompt 
+    bootloader will not require any key press. This task is used in 
+    combination with KubeVirt. It is part of windows-efi-installer pipeline 
+    https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/examples/pipelines/windows-efi-installer.
   params:
     - name: pvcName
       description: PersistentVolumeClaim which contains windows iso.
@@ -739,12 +755,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmiNamespace.params.task.kubevirt.io/type: namespace
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt wait for VMI status"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: wait-for-vmi-status
-    task.kubevirt.io/category: wait-for-vmi-status
+    app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status
 spec:
+  description: >-
+    This tasks waits until KubeVirt virtual machine is in some 
+    state. It can be used in pipeline where user needs to wait until e.g. 
+    VM finish some installation.
   params:
     - name: vmiName
       description: Name of a VirtualMachineInstance to wait for.

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -3,17 +3,18 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
-    delete.params.task.kubevirt.io/type: boolean
-    stop.params.task.kubevirt.io/type: boolean
-    timeout.params.task.kubevirt.io/type: duration
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt cleanup VM"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: cleanup-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: cleanup-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
+    This task can stop and delete VMs
   params:
     - description: Name of a VM to execute the action in.
       name: vmName
@@ -91,18 +92,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    sourceTemplateName.params.task.kubevirt.io/kind: Template
-    sourceTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    sourceTemplateNamespace.params.task.kubevirt.io/type: namespace
-    targetTemplateName.params.task.kubevirt.io/kind: Template
-    targetTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    targetTemplateNamespace.params.task.kubevirt.io/type: namespace
-    allowReplace.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt copy template"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: copy-template
-    task.kubevirt.io/category: copy-template
+    app.kubernetes.io/version: v0.17.0
   name: copy-template
 spec:
+  description: >-
+    Automates the copying of OpenShift template. The task copies original template 
+    and saves it under new name or if parameter allowReplace is true, then it replaces 
+    template with the same name.
   params:
     - name: sourceTemplateName
       description: Name of an OpenShift template to copy template from.
@@ -151,24 +153,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/kind: VirtualMachine
-    manifest.params.task.kubevirt.io/apiVersion: kubevirt.io/v1
-    namespace.params.task.kubevirt.io/type: namespace
-    dataVolumes.params.task.kubevirt.io/kind: DataVolume
-    dataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    ownDataVolumes.params.task.kubevirt.io/kind: DataVolume
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    persistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    startVM.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt create VM from manifest"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: create-vm-from-manifest
-    task.kubevirt.io/category: create-vm
+    app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+    User can create VM from manifest or with the same parameters as for virtctl.
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
     - name: manifest
       description: YAML manifest of a VirtualMachine resource to be created.
@@ -218,27 +215,20 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt create VM from template"
+    tekton.dev/platforms: "linux/amd64"
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/type: vm-template-name
-    templateName.params.task.kubevirt.io/kind: Template
-    templateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    templateNamespace.params.task.kubevirt.io/type: namespace
-    templateParams.params.task.kubevirt.io/type: template-params-array
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    dataVolumes.params.task.kubevirt.io/kind: DataVolume
-    dataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    ownDataVolumes.params.task.kubevirt.io/kind: DataVolume
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    persistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    startVM.params.task.kubevirt.io/type: boolean
   labels:
-    task.kubevirt.io/type: create-vm-from-template
-    task.kubevirt.io/category: create-vm
+    app.kubernetes.io/version: v0.17.0
   name: create-vm-from-template
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+    User can create VM from OpenShift template.
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
     - name: templateName
       description: Name of an OKD template to create VM from.
@@ -293,15 +283,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    customizeCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt customize"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-customize
-    task.kubevirt.io/category: disk-virt-customize
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize
 spec:
+  description: >-
+    Run virt-customize command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-customize script in. PVC should be in the same namespace as taskrun/pipelinerun.
@@ -421,15 +413,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    sysprepCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt sysprep"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-sysprep
-    task.kubevirt.io/category: disk-virt-sysprep
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep
 spec:
+  description: >-
+    Run virt-sysprep command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-sysprep script in. PVC should be in the same namespace as taskrun/pipelinerun.
@@ -549,14 +543,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt execute in vm"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: execute-in-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: execute-in-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
   params:
     - description: Name of a VM to execute the action in.
       name: vmName
@@ -615,18 +612,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    publicKeySecretName.params.task.kubevirt.io/kind: Secret
-    publicKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    publicKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeySecretName.params.task.kubevirt.io/kind: Secret
-    privateKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    privateKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeyConnectionOptions.params.task.kubevirt.io/type: private-key-options-array
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt generate ssh keys"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: generate-ssh-keys
-    task.kubevirt.io/category: generate-ssh-keys
+    app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys
 spec:
+  description: >-
+    Generate SSH keys which can be used for KubeVirt virtual machines.
   params:
     - name: publicKeySecretName
       description: Name of a new or existing secret to append the generated public key to. The name will be generated and new secret created if not specified.
@@ -687,12 +683,13 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    waitForSuccess.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify data object"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-data-object
-    task.kubevirt.io/category: modify-data-object
+    app.kubernetes.io/version: v0.17.0
   name: modify-data-object
 spec:
   description: >-
@@ -759,21 +756,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/kind: Template
-    templateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    templateNamespace.params.task.kubevirt.io/kind: namespace
-    cpuSockets.params.task.kubevirt.io/type: number
-    cpuCores.params.task.kubevirt.io/type: number
-    cpuThreads.params.task.kubevirt.io/type: number
-    memory.params.task.kubevirt.io/type: memory
-    deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
-    deleteTemplateParameters.params.task.kubevirt.io/type: boolean
-    deleteTemplate.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify VM template"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-vm-template
-    task.kubevirt.io/category: modify-vm-template
+    app.kubernetes.io/version: v0.17.0
   name: modify-vm-template
 spec:
+  description: >-
+    Automates the modifying of OpenShift template with KubeVirt virtual machine. 
+    This task is working only with https://github.com/kubevirt/common-templates. 
+    Other templates will not work.
   params:
     - name: templateName
       description: Name of an OpenShift template.
@@ -906,11 +901,24 @@ spec:
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify Windows iso"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-windows-iso-file
-    task.kubevirt.io/category: modify-windows-iso-file
+    app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file
 spec:
+  description: >-
+    This tasks is modifying windows iso file. It replaces prompt 
+    bootloader with non prompt one. This helps with automation of 
+    windows installation which requires EFI - the prompt bootloader will not 
+    continue with installation until some key is pressed. The non prompt 
+    bootloader will not require any key press. This task is used in 
+    combination with KubeVirt. It is part of windows-efi-installer pipeline 
+    https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/examples/pipelines/windows-efi-installer.
   params:
     - name: pvcName
       description: PersistentVolumeClaim which contains windows iso.
@@ -1024,12 +1032,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmiNamespace.params.task.kubevirt.io/type: namespace
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt wait for VMI status"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: wait-for-vmi-status
-    task.kubevirt.io/category: wait-for-vmi-status
+    app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status
 spec:
+  description: >-
+    This tasks waits until KubeVirt virtual machine is in some 
+    state. It can be used in pipeline where user needs to wait until e.g. 
+    VM finish some installation.
   params:
     - name: vmiName
       description: Name of a VirtualMachineInstance to wait for.

--- a/scripts/copy-released-manifests.sh
+++ b/scripts/copy-released-manifests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+REPO_DIR="$(realpath "${SCRIPT_DIR}/..")"
+
+source "${SCRIPT_DIR}/common.sh"
+visit "${REPO_DIR}/tasks"
+    for TASK_NAME in *; do
+        mkdir -p "${REPO_DIR}/release/tasks/${TASK_NAME}/${RELEASE_VERSION:1}"
+        cp -r "${TASK_NAME}/." "${REPO_DIR}/release/tasks/${TASK_NAME}/${RELEASE_VERSION:1}/"
+    done
+leave
+
+#preparation for pipeline releases
+#TODO copy pipelines from ssp operator
+mkdir -p "${REPO_DIR}/release/pipelines/windows-efi-installer/${RELEASE_VERSION:1}"
+mkdir -p "${REPO_DIR}/release/pipelines/windows-bios-installer/${RELEASE_VERSION:1}"
+mkdir -p "${REPO_DIR}/release/pipelines/windows-customize/${RELEASE_VERSION:1}"

--- a/scripts/run-ah-linter.sh
+++ b/scripts/run-ah-linter.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p ah
+AH_VERSION=$(curl -s https://api.github.com/repos/artifacthub/hub/releases | \
+            jq -r '[.[]|select(.prerelease==false) | .tag_name] | sort | last')
+
+curl -L "https://github.com/artifacthub/hub/releases/download/${AH_VERSION}/ah_${AH_VERSION:1}_linux_amd64.tar.gz" | tar -C ah/ -xzf -
+
+make copy-released-manifests
+
+./ah/ah lint -k tekton-task -p release/tasks/
+#TODO uncomment when pipelines are migrated to this repo
+#./ah/ah lint -k tekton-pipeline -p release/pipelines/
+
+rm -r ah

--- a/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/tasks/cleanup-vm/cleanup-vm.yaml
@@ -3,17 +3,18 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
-    delete.params.task.kubevirt.io/type: boolean
-    stop.params.task.kubevirt.io/type: boolean
-    timeout.params.task.kubevirt.io/type: duration
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt cleanup VM"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: cleanup-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: cleanup-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
+    This task can stop and delete VMs
   params:
     - description: Name of a VM to execute the action in.
       name: vmName

--- a/tasks/copy-template/copy-template.yaml
+++ b/tasks/copy-template/copy-template.yaml
@@ -4,18 +4,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    sourceTemplateName.params.task.kubevirt.io/kind: Template
-    sourceTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    sourceTemplateNamespace.params.task.kubevirt.io/type: namespace
-    targetTemplateName.params.task.kubevirt.io/kind: Template
-    targetTemplateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    targetTemplateNamespace.params.task.kubevirt.io/type: namespace
-    allowReplace.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt copy template"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: copy-template
-    task.kubevirt.io/category: copy-template
+    app.kubernetes.io/version: v0.17.0
   name: copy-template
 spec:
+  description: >-
+    Automates the copying of OpenShift template. The task copies original template 
+    and saves it under new name or if parameter allowReplace is true, then it replaces 
+    template with the same name.
   params:
     - name: sourceTemplateName
       description: Name of an OpenShift template to copy template from.

--- a/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -3,24 +3,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/kind: VirtualMachine
-    manifest.params.task.kubevirt.io/apiVersion: kubevirt.io/v1
-    namespace.params.task.kubevirt.io/type: namespace
-    dataVolumes.params.task.kubevirt.io/kind: DataVolume
-    dataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    ownDataVolumes.params.task.kubevirt.io/kind: DataVolume
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    persistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    startVM.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt create VM from manifest"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: create-vm-from-manifest
-    task.kubevirt.io/category: create-vm
+    app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+    User can create VM from manifest or with the same parameters as for virtctl.
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
     - name: manifest
       description: YAML manifest of a VirtualMachine resource to be created.

--- a/tasks/create-vm-from-template/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/create-vm-from-template.yaml
@@ -3,27 +3,20 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt create VM from template"
+    tekton.dev/platforms: "linux/amd64"
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/type: vm-template-name
-    templateName.params.task.kubevirt.io/kind: Template
-    templateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    templateNamespace.params.task.kubevirt.io/type: namespace
-    templateParams.params.task.kubevirt.io/type: template-params-array
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    dataVolumes.params.task.kubevirt.io/kind: DataVolume
-    dataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    ownDataVolumes.params.task.kubevirt.io/kind: DataVolume
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    persistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: v1
-    startVM.params.task.kubevirt.io/type: boolean
   labels:
-    task.kubevirt.io/type: create-vm-from-template
-    task.kubevirt.io/category: create-vm
+    app.kubernetes.io/version: v0.17.0
   name: create-vm-from-template
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+    User can create VM from OpenShift template.
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
     - name: templateName
       description: Name of an OKD template to create VM from.

--- a/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -3,15 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    customizeCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt customize"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-customize
-    task.kubevirt.io/category: disk-virt-customize
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize
 spec:
+  description: >-
+    Run virt-customize command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-customize script in. PVC should be in the same namespace as taskrun/pipelinerun.

--- a/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -3,15 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: PersistentVolumeClaim
-    pvc.params.task.kubevirt.io/apiVersion: v1
-    sysprepCommands.params.task.kubevirt.io/type: script
-    verbose.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt disk virt sysprep"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: disk-virt-sysprep
-    task.kubevirt.io/category: disk-virt-sysprep
+    app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep
 spec:
+  description: >-
+    Run virt-sysprep command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-sysprep script in. PVC should be in the same namespace as taskrun/pipelinerun.

--- a/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/tasks/execute-in-vm/execute-in-vm.yaml
@@ -3,14 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: namespace
-    secretName.params.task.kubevirt.io/type: execute-in-vm-secret
-    script.params.task.kubevirt.io/type: script
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt execute in vm"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: execute-in-vm
-    task.kubevirt.io/category: execute-in-vm
+    app.kubernetes.io/version: v0.17.0
   name: execute-in-vm
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
   params:
     - description: Name of a VM to execute the action in.
       name: vmName

--- a/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -3,18 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    publicKeySecretName.params.task.kubevirt.io/kind: Secret
-    publicKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    publicKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeySecretName.params.task.kubevirt.io/kind: Secret
-    privateKeySecretName.params.task.kubevirt.io/apiVersion: v1
-    privateKeySecretNamespace.params.task.kubevirt.io/type: namespace
-    privateKeyConnectionOptions.params.task.kubevirt.io/type: private-key-options-array
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt generate ssh keys"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: generate-ssh-keys
-    task.kubevirt.io/category: generate-ssh-keys
+    app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys
 spec:
+  description: >-
+    Generate SSH keys which can be used for KubeVirt virtual machines.
   params:
     - name: publicKeySecretName
       description: Name of a new or existing secret to append the generated public key to. The name will be generated and new secret created if not specified.

--- a/tasks/modify-data-object/modify-data-object.yaml
+++ b/tasks/modify-data-object/modify-data-object.yaml
@@ -3,12 +3,13 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: resource-yaml
-    manifest.params.task.kubevirt.io/apiVersion: cdi.kubevirt.io/v1beta1
-    waitForSuccess.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify data object"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-data-object
-    task.kubevirt.io/category: modify-data-object
+    app.kubernetes.io/version: v0.17.0
   name: modify-data-object
 spec:
   description: >-

--- a/tasks/modify-vm-template/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/modify-vm-template.yaml
@@ -4,21 +4,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/kind: Template
-    templateName.params.task.kubevirt.io/apiVersion: template.openshift.io/v1
-    templateNamespace.params.task.kubevirt.io/kind: namespace
-    cpuSockets.params.task.kubevirt.io/type: number
-    cpuCores.params.task.kubevirt.io/type: number
-    cpuThreads.params.task.kubevirt.io/type: number
-    memory.params.task.kubevirt.io/type: memory
-    deleteDatavolumeTemplate.params.task.kubevirt.io/type: boolean
-    deleteTemplateParameters.params.task.kubevirt.io/type: boolean
-    deleteTemplate.params.task.kubevirt.io/type: boolean
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify VM template"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-vm-template
-    task.kubevirt.io/category: modify-vm-template
+    app.kubernetes.io/version: v0.17.0
   name: modify-vm-template
 spec:
+  description: >-
+    Automates the modifying of OpenShift template with KubeVirt virtual machine. 
+    This task is working only with https://github.com/kubevirt/common-templates. 
+    Other templates will not work.
   params:
     - name: templateName
       description: Name of an OpenShift template.

--- a/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -2,11 +2,24 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt modify Windows iso"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: modify-windows-iso-file
-    task.kubevirt.io/category: modify-windows-iso-file
+    app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file
 spec:
+  description: >-
+    This tasks is modifying windows iso file. It replaces prompt 
+    bootloader with non prompt one. This helps with automation of 
+    windows installation which requires EFI - the prompt bootloader will not 
+    continue with installation until some key is pressed. The non prompt 
+    bootloader will not require any key press. This task is used in 
+    combination with KubeVirt. It is part of windows-efi-installer pipeline 
+    https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/examples/pipelines/windows-efi-installer.
   params:
     - name: pvcName
       description: PersistentVolumeClaim which contains windows iso.

--- a/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -3,12 +3,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmiNamespace.params.task.kubevirt.io/type: namespace
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt wait for VMI status"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: wait-for-vmi-status
-    task.kubevirt.io/category: wait-for-vmi-status
+    app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status
 spec:
+  description: >-
+    This tasks waits until KubeVirt virtual machine is in some 
+    state. It can be used in pipeline where user needs to wait until e.g. 
+    VM finish some installation.
   params:
     - name: vmiName
       description: Name of a VirtualMachineInstance to wait for.

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -4,18 +4,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    sourceTemplateName.params.task.kubevirt.io/kind: {{ task_param_types.template_kind }}
-    sourceTemplateName.params.task.kubevirt.io/apiVersion: {{ task_param_types.template_version }}
-    sourceTemplateNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    targetTemplateName.params.task.kubevirt.io/kind: {{ task_param_types.template_kind }}
-    targetTemplateName.params.task.kubevirt.io/apiVersion: {{ task_param_types.template_version }}
-    targetTemplateNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    allowReplace.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Automates the copying of OpenShift template. The task copies original template 
+    and saves it under new name or if parameter allowReplace is true, then it replaces 
+    template with the same name.
   params:
     - name: sourceTemplateName
       description: Name of an OpenShift template to copy template from.

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -3,34 +3,26 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-{% if task_name == "create-vm-from-manifest" %}
-    manifest.params.task.kubevirt.io/type: {{ task_param_types.resource_yaml }}
-    manifest.params.task.kubevirt.io/kind: {{ task_param_types.vm_kind}}
-    manifest.params.task.kubevirt.io/apiVersion: {{ task_param_types.vm_version }}
-    namespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-{% elif task_name == "create-vm-from-template" %}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
+{% if task_name == "create-vm-from-template" %}
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/type: {{ task_param_types.vm_template_name }}
-    templateName.params.task.kubevirt.io/kind: {{ task_param_types.template_kind }}
-    templateName.params.task.kubevirt.io/apiVersion: {{ task_param_types.template_version }}
-    templateNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    templateParams.params.task.kubevirt.io/type: {{ task_param_types.template_params_array }}
-    vmNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
 {% endif %}
-    dataVolumes.params.task.kubevirt.io/kind: {{ task_param_types.datavolume_kind }}
-    dataVolumes.params.task.kubevirt.io/apiVersion: {{ task_param_types.cdi_beta_api_version }}
-    ownDataVolumes.params.task.kubevirt.io/kind: {{ task_param_types.datavolume_kind }}
-    ownDataVolumes.params.task.kubevirt.io/apiVersion: {{ task_param_types.cdi_beta_api_version }}
-    persistentVolumeClaims.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}
-    persistentVolumeClaims.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    ownPersistentVolumeClaims.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}
-    ownPersistentVolumeClaims.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    startVM.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Automates creation of the KubeVirt virtual machine.
+{% if task_name == "create-vm-from-manifest" %}
+    User can create VM from manifest or with the same parameters as for virtctl.
+{% elif task_name == "create-vm-from-template" %}
+    User can create VM from OpenShift template.
+{% endif %}
+    It is possible to immediatelly start the vm after creation with startVM parameter.
   params:
 {% if task_name == "create-vm-from-manifest" %}
     - name: manifest

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -3,15 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}
-    pvc.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    customizeCommands.params.task.kubevirt.io/type: {{ task_param_types.script }}
-    verbose.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Run virt-customize command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-customize script in. PVC should be in the same namespace as taskrun/pipelinerun.

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -3,15 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    pvc.params.task.kubevirt.io/kind: {{ task_param_types.pvc_kind }}
-    pvc.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    sysprepCommands.params.task.kubevirt.io/type: {{ task_param_types.script }}
-    verbose.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Run virt-sysprep command on given PVC. Usefull for manipulation with virtual machine's disks.
   params:
     - name: pvc
       description: PersistentVolumeClaim to run the the virt-sysprep script in. PVC should be in the same namespace as taskrun/pipelinerun.

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -3,19 +3,20 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    secretName.params.task.kubevirt.io/type: {{ task_param_types.execute_in_vm_secret }}
-    script.params.task.kubevirt.io/type: {{ task_param_types.script }}
-{% if is_cleanup %}
-    delete.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
-    stop.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
-    timeout.params.task.kubevirt.io/type: {{ task_param_types.duration }}
-{% endif %}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Run commands in KubeVirt virtual machine.
+{% if is_cleanup %}
+    This task can stop and delete VMs
+{% endif %}
   params:
     - description: Name of a VM to execute the action in.
       name: vmName

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -3,18 +3,17 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    publicKeySecretName.params.task.kubevirt.io/kind: {{ task_param_types.secret_kind }}
-    publicKeySecretName.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    publicKeySecretNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    privateKeySecretName.params.task.kubevirt.io/kind: {{ task_param_types.secret_kind }}
-    privateKeySecretName.params.task.kubevirt.io/apiVersion: {{ task_param_types.v1_version }}
-    privateKeySecretNamespace.params.task.kubevirt.io/type: {{ task_param_types.namespace }}
-    privateKeyConnectionOptions.params.task.kubevirt.io/type: {{ task_param_types.private_key_options_array }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Generate SSH keys which can be used for KubeVirt virtual machines.
   params:
     - name: publicKeySecretName
       description: Name of a new or existing secret to append the generated public key to. The name will be generated and new secret created if not specified.

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -3,12 +3,13 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    manifest.params.task.kubevirt.io/type: {{ task_param_types.resource_yaml }}
-    manifest.params.task.kubevirt.io/apiVersion: {{ task_param_types.cdi_beta_api_version }}
-    waitForSuccess.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -4,21 +4,19 @@ kind: Task
 metadata:
   annotations:
     tekton.dev/deprecated: "true"
-    templateName.params.task.kubevirt.io/kind: {{ task_param_types.template_kind }}
-    templateName.params.task.kubevirt.io/apiVersion: {{ task_param_types.template_version }}
-    templateNamespace.params.task.kubevirt.io/kind: {{ task_param_types.namespace }}
-    cpuSockets.params.task.kubevirt.io/type: {{ task_param_types.number }}
-    cpuCores.params.task.kubevirt.io/type: {{ task_param_types.number }}
-    cpuThreads.params.task.kubevirt.io/type: {{ task_param_types.number }}
-    memory.params.task.kubevirt.io/type: {{ task_param_types.memory }}
-    deleteDatavolumeTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
-    deleteTemplateParameters.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
-    deleteTemplate.params.task.kubevirt.io/type: {{ task_param_types.boolean }}
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    Automates the modifying of OpenShift template with KubeVirt virtual machine. 
+    This task is working only with https://github.com/kubevirt/common-templates. 
+    Other templates will not work.
   params:
     - name: templateName
       description: Name of an OpenShift template.

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -2,11 +2,24 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    This tasks is modifying windows iso file. It replaces prompt 
+    bootloader with non prompt one. This helps with automation of 
+    windows installation which requires EFI - the prompt bootloader will not 
+    continue with installation until some key is pressed. The non prompt 
+    bootloader will not require any key press. This task is used in 
+    combination with KubeVirt. It is part of windows-efi-installer pipeline 
+    https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/examples/pipelines/windows-efi-installer.
   params:
     - name: pvcName
       description: PersistentVolumeClaim which contains windows iso.

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -3,12 +3,19 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
-    vmiNamespace.params.task.kubevirt.io/type: namespace
+    tekton.dev/pipelines.minVersion: "0.43.0"
+    tekton.dev/categories: Automation
+    tekton.dev/tags: kubevirt
+    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/platforms: "linux/amd64"
   labels:
-    task.kubevirt.io/type: {{ task_name }}
-    task.kubevirt.io/category: {{ task_category }}
+    app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}
 spec:
+  description: >-
+    This tasks waits until KubeVirt virtual machine is in some 
+    state. It can be used in pipeline where user needs to wait until e.g. 
+    VM finish some installation.
   params:
     - name: vmiName
       description: Name of a VirtualMachineInstance to wait for.


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the requirement for onboarding tasks to artifact hub is, to have a special folder with released manifests, which is then followed by artifacthub.
This PR adds a new step in release pipeline, which copies generated manifests from tasks/ into released-tasks folder with new tag. Then this change will be added as a part of PR to main branch (artifacthub is following main by default), which updates repo with new release tag. 
The result tree of released-tasks folder will look like this: 
```
release/tasks/cleanup-vm/
├── 0.17.0
│   ├── cleanup-vm.yaml
│   ├── examples
│   │   ├── secrets
│   │   │   ├── ssh-secret-advanced.yaml
│   │   │   └── ssh-secret.yaml
│   │   └── taskruns
│   │       ├── cleanup-vm-simple-taskrun.yaml
│   │       └── cleanup-vm-with-ssh-taskrun.yaml
│   └── README.md
└── 0.18.0
    ├── cleanup-vm.yaml
    ├── examples
    │   ├── secrets
    │   │   ├── ssh-secret-advanced.yaml
    │   │   └── ssh-secret.yaml
    │   └── taskruns
    │       ├── cleanup-vm-simple-taskrun.yaml
    │       └── cleanup-vm-with-ssh-taskrun.yaml
    └── README.md
```
It also refactors labels and annotations in each task to match requirements of artifact hub

**Release note**:
```
copy released manifests into released-tasks folder
```
