### PR TITLE
feat: add artifact hub annotations

### DIFF
--- a/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
+++ b/manifests/kubernetes/kubevirt-tekton-tasks-kubernetes.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt cleanup VM"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: cleanup-vm
@@ -96,6 +103,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt create VM from manifest"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest
@@ -158,6 +172,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt customize"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize
@@ -288,6 +309,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt sysprep"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep
@@ -418,6 +446,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt execute in vm"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: execute-in-vm
@@ -487,6 +522,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt generate ssh keys"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys
@@ -558,6 +600,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify data object"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-data-object
@@ -630,6 +679,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify Windows iso"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file
@@ -760,6 +816,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt wait for VMI status"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status

--- a/manifests/okd/kubevirt-tekton-tasks-okd.yaml
+++ b/manifests/okd/kubevirt-tekton-tasks-okd.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt cleanup VM"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: cleanup-vm
@@ -97,6 +104,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt copy template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: copy-template
@@ -158,6 +172,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt create VM from manifest"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest
@@ -220,6 +241,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt create VM from template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
     tekton.dev/deprecated: "true"
   labels:
     app.kubernetes.io/version: v0.17.0
@@ -288,6 +316,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt customize"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize
@@ -418,6 +453,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt sysprep"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep
@@ -548,6 +590,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt execute in vm"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: execute-in-vm
@@ -617,6 +666,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt generate ssh keys"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys
@@ -688,6 +744,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify data object"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-data-object
@@ -761,6 +824,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify VM template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-vm-template
@@ -907,6 +977,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify Windows iso"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file
@@ -1037,6 +1114,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt wait for VMI status"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status

--- a/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/tasks/cleanup-vm/cleanup-vm.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt cleanup VM"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: cleanup-vm

--- a/tasks/copy-template/copy-template.yaml
+++ b/tasks/copy-template/copy-template.yaml
@@ -9,6 +9,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt copy template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: copy-template

--- a/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt create VM from manifest"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: create-vm-from-manifest

--- a/tasks/create-vm-from-template/create-vm-from-template.yaml
+++ b/tasks/create-vm-from-template/create-vm-from-template.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt create VM from template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
     tekton.dev/deprecated: "true"
   labels:
     app.kubernetes.io/version: v0.17.0

--- a/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt customize"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-customize

--- a/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt sysprep"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: disk-virt-sysprep

--- a/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/tasks/execute-in-vm/execute-in-vm.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt execute in vm"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: execute-in-vm

--- a/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt generate ssh keys"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: generate-ssh-keys

--- a/tasks/modify-data-object/modify-data-object.yaml
+++ b/tasks/modify-data-object/modify-data-object.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify data object"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-data-object

--- a/tasks/modify-vm-template/modify-vm-template.yaml
+++ b/tasks/modify-vm-template/modify-vm-template.yaml
@@ -9,6 +9,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify VM template"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-vm-template

--- a/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt modify Windows iso"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: modify-windows-iso-file

--- a/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt wait for VMI status"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: v0.17.0
   name: wait-for-vmi-status

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -9,6 +9,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
 {% if task_name == "create-vm-from-template" %}
     tekton.dev/deprecated: "true"
 {% endif %}

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -9,6 +9,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -8,6 +8,13 @@ metadata:
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
+    artifacthub.io/maintainers: |
+      - name: Karel Simon
+        email: ksimon@redhat.com
+    artifacthub.io/provider: KubeVirt
+    artifacthub.io/recommendations: |
+      - url: https://kubevirt.io/
+    artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}
   name: {{ task_name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add artifact hub annotations

this commit adds special artifact hub annotations, which add information about maintainers, recommendations, provider, ... These annotation are used only by artifact hub.
Signed-off-by: Karel Simon <ksimon@redhat.com>

**Release note**:
```
Add artifact hub annotations
```
