### PR TITLE
feat: disable PRs to ssp operator during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,15 +51,6 @@ jobs:
           asset_name: kubevirt-tekton-tasks-okd.yaml
           asset_content_type: text/plain
 
-      # triggers https://github.com/kubevirt/ssp-operator/blob/main/.github/workflows/release-tekton-tasks.yaml
-      - name: Trigger ssp-operator
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.ACTIONS_TOKEN }}
-          repository: kubevirt/ssp-operator
-          event-type: release-tekton-tasks
-          client-payload: '{"release_version": "${{ steps.get_release.outputs.tag_name }}"}'
-
       - name: Update tekton tasks manifests
         run: |
           # Define vars


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: disable PRs to ssp operator during release

tekton tasks will no longer be part of ssp operator

**Release note**:
```
NONE
```
