### PR TITLE
feat: update libguestfs container to v1.1.1

### DIFF
--- a/build/Containerfile.DiskVirt
+++ b/build/Containerfile.DiskVirt
@@ -16,7 +16,7 @@ RUN task_names=("disk-virt-customize" "disk-virt-sysprep"); \
         CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o /out/${TASK_NAME} cmd/${TASK_NAME}/main.go; \
     done
 
-FROM quay.io/kubevirt/libguestfs-tools:v0.59.0
+FROM quay.io/kubevirt/libguestfs-tools:v1.1.1
 ENV USER_UID=1001 \
     USER_NAME=tekton-tasks-disk-virt \
     HOME=/home/${USER_NAME}


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: update libguestfs container to v1.1.1

this commit updates libguestfs container to newest available v1.1.1.
I created manually this PR, because https://github.com/kubevirt/project-infra/pull/3186 is not working and I need to investigate why its not working

**Release note**:
```
Update libguestfs container to v1.1.1

```
