### PR TITLE
fix: tekton version in templates and tasks

### DIFF
--- a/tasks/cleanup-vm/examples/taskruns/cleanup-vm-simple-taskrun.yaml
+++ b/tasks/cleanup-vm/examples/taskruns/cleanup-vm-simple-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: cleanup-vm-simple-taskrun

--- a/tasks/cleanup-vm/examples/taskruns/cleanup-vm-with-ssh-taskrun.yaml
+++ b/tasks/cleanup-vm/examples/taskruns/cleanup-vm-with-ssh-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: cleanup-vm-with-ssh-taskrun

--- a/tasks/copy-template/examples/taskruns/copy-template-taskrun.yaml
+++ b/tasks/copy-template/examples/taskruns/copy-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: copy-template-taskrun

--- a/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun.yaml
+++ b/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: create-vm-from-manifest-taskrun

--- a/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
+++ b/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: create-vm-from-template-taskrun

--- a/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
+++ b/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   password: mysecretpassword
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: disk-virt-customize-taskrun-workspace

--- a/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun.yaml
+++ b/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: disk-virt-customize-taskrun

--- a/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   password: mysecretpassword
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: disk-virt-sysprep-taskrun-workspace

--- a/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun.yaml
+++ b/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: disk-virt-sysprep-taskrun

--- a/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun.yaml
+++ b/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: execute-in-vm-with-ssh-taskrun

--- a/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun.yaml
+++ b/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: generate-ssh-keys-advanced-taskrun

--- a/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-simple-taskrun.yaml
+++ b/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-simple-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: generate-ssh-keys-simple-taskrun

--- a/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun.yaml
+++ b/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: modify-data-object-taskrun

--- a/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun.yaml
+++ b/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: modify-vm-template-taskrun

--- a/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
+++ b/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: modify-windows-iso-file-taskrun

--- a/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun.yaml
+++ b/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: wait-for-vmi-status-taskrun

--- a/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
+++ b/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/copy-template/examples/copy-template-taskrun.yaml
+++ b/templates/copy-template/examples/copy-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
+++ b/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
+++ b/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   password: mysecretpassword
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item }}

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item }}

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
@@ -6,7 +6,7 @@ type: Opaque
 stringData:
   password: mysecretpassword
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item }}

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item }}

--- a/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
+++ b/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
+++ b/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
+++ b/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
+++ b/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
+++ b/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}

--- a/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
+++ b/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: {{ item.taskrun_with_flavor_name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: tekton version in templates and tasks

fix tekton version to v1 in templates and tasks

**Release note**:
```
Use tekton v1 in taskruns
```
