### PR TITLE
fix: Remove use of kubevirt.io/v1alpha3 in example pipelines

### DIFF
--- a/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
+++ b/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
@@ -55,7 +55,7 @@ spec:
       params:
         - name: manifest
           value: |
-            apiVersion: kubevirt.io/v1alpha3
+            apiVersion: kubevirt.io/v1
             kind: VirtualMachine
             metadata:
               generateName: flasker-vm-

--- a/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
+++ b/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
@@ -47,7 +47,7 @@ spec:
       params:
         - name: manifest
           value: |
-            apiVersion: kubevirt.io/v1alpha3
+            apiVersion: kubevirt.io/v1
             kind: VirtualMachine
             metadata:
               generateName: virt-sysprep-updated-vm-


### PR DESCRIPTION
**What this PR does / why we need it**:

This version is now deprecated in favour of v1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubevirt/ssp-operator/issues/716

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
