### PR TITLE
chore: replace hardcoded annotations in templates with variables

### DIFF
--- a/scripts/ansible/branding.yaml
+++ b/scripts/ansible/branding.yaml
@@ -1,0 +1,5 @@
+display_name_provider: "KubeVirt"
+provider: "KubeVirt"
+maintainer_name: "Karel Simon"
+maintainer_email: "ksimon@redhat.com"
+recommendation_url: "https://kubevirt.io/"

--- a/templates/cleanup-vm/generate-task.yaml
+++ b/templates/cleanup-vm/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/cleanup-vm.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   vars:
     execute_in_vm_manifest_templates_dir: ../execute-in-vm/manifests
     execute_in_vm_examples_templates_dir: ../execute-in-vm/examples

--- a/templates/copy-template/generate-task.yaml
+++ b/templates/copy-template/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/copy-template.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -7,14 +7,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/create-vm-from-manifest/generate-task.yaml
+++ b/templates/create-vm-from-manifest/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/create-vm-from-manifest.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
 {% if task_name == "create-vm-from-template" %}
     tekton.dev/deprecated: "true"

--- a/templates/create-vm-from-template/generate-task.yaml
+++ b/templates/create-vm-from-template/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/create-vm-from-template.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   vars:
     create_vm_from_manifest_manifest_templates_dir: ../create-vm-from-manifest/manifests
   tasks:

--- a/templates/disk-virt-customize/generate-task.yaml
+++ b/templates/disk-virt-customize/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/disk-virt-customize.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/disk-virt-sysprep/generate-task.yaml
+++ b/templates/disk-virt-sysprep/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/disk-virt-sysprep.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/execute-in-vm/generate-task.yaml
+++ b/templates/execute-in-vm/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/execute-in-vm.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   vars:
     examples_secrets_output_dir: "{{ examples_output_dir }}/secrets"
     ssh_secret_name: "ssh-secret"

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/generate-ssh-keys/generate-task.yaml
+++ b/templates/generate-ssh-keys/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/generate-ssh-keys.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/modify-data-object/generate-task.yaml
+++ b/templates/modify-data-object/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/modify-data-object.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/modify-vm-template/generate-task.yaml
+++ b/templates/modify-vm-template/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/modify-vm-template.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -7,14 +7,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/modify-windows-iso-file/generate-task.yaml
+++ b/templates/modify-windows-iso-file/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/modify-windows-iso-file.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}

--- a/templates/wait-for-vmi-status/generate-task.yaml
+++ b/templates/wait-for-vmi-status/generate-task.yaml
@@ -6,6 +6,7 @@
     - ../../configs/wait-for-vmi-status.yaml
     - ../../scripts/ansible/enums.yaml
     - ../../scripts/ansible/common.yaml
+    - ../../scripts/ansible/branding.yaml
   tasks:
     - name: Init
       include_tasks: "{{ repo_dir }}/scripts/ansible/init-task-generation.yaml"

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -6,14 +6,14 @@ metadata:
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
-    tekton.dev/displayName: "KubeVirt {{ nice_name }}"
+    tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
     tekton.dev/platforms: "linux/amd64"
     artifacthub.io/maintainers: |
-      - name: Karel Simon
-        email: ksimon@redhat.com
-    artifacthub.io/provider: KubeVirt
+      - name: {{ maintainer_name }}
+        email: {{ maintainer_email }}
+    artifacthub.io/provider: {{ provider }}
     artifacthub.io/recommendations: |
-      - url: https://kubevirt.io/
+      - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
     app.kubernetes.io/version: {{ version }}


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: replace hardcoded annotations in templates with variables

To enable automation of OCP V releases of tekton tasks, this commit updates template manifests to use variables in annotations.

**Release note**:
```
NONE
```
