### PR TITLE
chore: update fedora version in CI image

### DIFF
--- a/automation/generatetasks/build/Dockerfile
+++ b/automation/generatetasks/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:39
 
 ENV HOME=/go/src/github.com/kubevirt/kubevirt-tekton-tasks/ \
     USER_UID=1001 \


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: update fedora version in CI image

Update fedora version to 39 in test base image.

**Release note**:
```
NONE
```
