### PR TITLE
chore: improve README of pipelines

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -32,13 +32,15 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 1. `create-vm-root-disk` Task creates an empty DataVolume.
 2. `create-vm` Task creates a VirtualMachine called `windows-bios-installer-*`
    from the empty DataVolume and with the `windows-bios-installer-cd-rom` DataVolume attached as a CD-ROM.
-   A second DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`).
+   A second DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the empty DataVolume.
 3. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 4. `cleanup-vm` deletes the installer VirtualMachine and ISO DataVolume (also in case of failure of the previous Tasks).
 5. The output artifact will be the `win10` DataVolume with the basic Windows installation.
    It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline run with resolver:
 ```yaml

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -25,13 +25,15 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ```
 
 1. `copy-vm-root-disk` Task copies PVC defined in `sourceDiskImageName` and `sourceDiskImageNamespace` parameters.
-2. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`).
+2. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`). The VirtualMachine has to be created in the same namespace as the source DataVolume.
 3. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 4. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
 5. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
 6. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline runs with resolvers:
 ```yaml

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -46,15 +46,17 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ```
 
 1. `create-vm-root-disk` creates empty DataVolume which is used for Windows installation.
-2. `import-win-iso` creates new datavolume with Windows ISO file with name defined in `isoDVName` parameter.
+2. `import-win-iso` creates new DataVolume with Windows ISO file with name defined in `isoDVName` parameter. The DataVolume needs to be in the same namespace as the PipelineRun (because the PVC is mounted into the PipelineRun pod).
 3. `modify-windows-iso-file` extracts imported ISO file, replaces prompt bootloader (which is used as a default one when EFI is used) with no-prompt bootloader, pack the updated files back to new ISO, convert the ISO and replaces original ISO with updated one.Replacement of bootloader is needed to be able to automate installation of Windows versions which require EFI.
-4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`).
+4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the DataVolume with the ISO file. In case you would like to run the VirtualMachine in a different namespace, both Datavolumes have to be copied to the same namespace as the VirtualMachine.
 5. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 6. `create-base-dv` Task creates an DataVolume with the specified name and namespace (Pipeline parameters `baseDvName` and `baseDvNamespace`). Then it clones the second DataVolume of the installation VirtualMachine into the new DataVolume.
 7. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
 8. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline runs with resolvers:
 ```yaml

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -32,13 +32,15 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 1. `create-vm-root-disk` Task creates an empty DataVolume.
 2. `create-vm` Task creates a VirtualMachine called `windows-bios-installer-*`
    from the empty DataVolume and with the `windows-bios-installer-cd-rom` DataVolume attached as a CD-ROM.
-   A second DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`).
+   A second DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the empty DataVolume.
 3. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 4. `cleanup-vm` deletes the installer VirtualMachine and ISO DataVolume (also in case of failure of the previous Tasks).
 5. The output artifact will be the `win10` DataVolume with the basic Windows installation.
    It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline run with resolver:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -25,13 +25,15 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ```
 
 1. `copy-vm-root-disk` Task copies PVC defined in `sourceDiskImageName` and `sourceDiskImageNamespace` parameters.
-2. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`).
+2. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`). The VirtualMachine has to be created in the same namespace as the source DataVolume.
 3. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 4. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
 5. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
 6. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -46,15 +46,17 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ```
 
 1. `create-vm-root-disk` creates empty DataVolume which is used for Windows installation.
-2. `import-win-iso` creates new datavolume with Windows ISO file with name defined in `isoDVName` parameter.
+2. `import-win-iso` creates new DataVolume with Windows ISO file with name defined in `isoDVName` parameter. The DataVolume needs to be in the same namespace as the PipelineRun (because the PVC is mounted into the PipelineRun pod).
 3. `modify-windows-iso-file` extracts imported ISO file, replaces prompt bootloader (which is used as a default one when EFI is used) with no-prompt bootloader, pack the updated files back to new ISO, convert the ISO and replaces original ISO with updated one.Replacement of bootloader is needed to be able to automate installation of Windows versions which require EFI.
-4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`).
+4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the DataVolume with the ISO file. In case you would like to run the VirtualMachine in a different namespace, both Datavolumes have to be copied to the same namespace as the VirtualMachine.
 5. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
 6. `create-base-dv` Task creates an DataVolume with the specified name and namespace (Pipeline parameters `baseDvName` and `baseDvNamespace`). Then it clones the second DataVolume of the installation VirtualMachine into the new DataVolume.
 7. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
 8. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
+
+Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: improve README of pipelines

this commit adds few notes about behaviour of pipelines and requirement to have ConfigMaps created before running pipelineRun.

**Release note**:
```
NONE
```
