### PR TITLE
chore: update libguestfs and virtio versions

### DIFF
--- a/build/Containerfile.DiskVirt
+++ b/build/Containerfile.DiskVirt
@@ -16,7 +16,7 @@ RUN task_names=("disk-virt-customize" "disk-virt-sysprep"); \
         CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o /out/${TASK_NAME} cmd/${TASK_NAME}/main.go; \
     done
 
-FROM quay.io/kubevirt/libguestfs-tools:v1.1.1
+FROM quay.io/kubevirt/libguestfs-tools:v1.2.0
 ENV USER_UID=1001 \
     USER_NAME=tekton-tasks-disk-virt \
     HOME=/home/${USER_NAME}

--- a/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
+++ b/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
@@ -51,7 +51,7 @@ spec:
     - name: virtioContainerDiskName
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       type: string
-      default: quay.io/kubevirt/virtio-container-disk:v1.1.1
+      default: quay.io/kubevirt/virtio-container-disk:v1.2.0
     - name: installCDRomName
       description: Name of datavolume which contains iso file.
       type: string

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -48,7 +48,7 @@ spec:
       description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       name: autounattendConfigMapName
       type: string
-    - default: quay.io/kubevirt/virtio-container-disk:v1.1.1
+    - default: quay.io/kubevirt/virtio-container-disk:v1.2.0
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       name: virtioContainerDiskName
       type: string

--- a/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
+++ b/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
@@ -51,7 +51,7 @@ spec:
     - name: virtioContainerDiskName
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       type: string
-      default: quay.io/kubevirt/virtio-container-disk:v1.1.1
+      default: quay.io/kubevirt/virtio-container-disk:v1.2.0
     - name: installCDRomName
       description: Name of datavolume which contains iso file.
       type: string

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -48,7 +48,7 @@ spec:
       description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       name: autounattendConfigMapName
       type: string
-    - default: quay.io/kubevirt/virtio-container-disk:v1.1.1
+    - default: quay.io/kubevirt/virtio-container-disk:v1.2.0
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       name: virtioContainerDiskName
       type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: update libguestfs and virtio versions
this commit updates virtio and libguestfs versions to latest possible

**Release note**:
```
Update libguestfs and virtio versions to 1.2.0
```
