### PR TITLE
chore: bump version to v0.19.0

### DIFF
--- a/makefile
+++ b/makefile
@@ -59,7 +59,7 @@ push-release-images:
 run-ah-linter:
 	./scripts/run-ah-linter.sh
 
-release: generate-yaml-tasks build-release-images push-release-images
+release: generate-yaml-tasks generate-pipelines build-release-images push-release-images
 
 vendor:
 	./scripts/vendor.sh

--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -66,7 +66,7 @@ spec:
         -   name: name
             value: windows-bios-installer
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 EOF
 ```

--- a/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -19,4 +19,4 @@ spec:
       - name: name
         value: windows-bios-installer
       - name: version
-        value: v0.18.0
+        value: v0.19.0

--- a/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
+++ b/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: windows-bios-installer
 spec:
   description: >-
@@ -78,7 +78,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       params:
         - name: manifest
           value: |-
@@ -181,7 +181,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       runAfter:
         - create-vm-root-disk
     - name: wait-for-vmi-status
@@ -209,7 +209,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   finally:
     - name: cleanup-vm
       params:
@@ -232,7 +232,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   results:
     - name: baseDvName
       description: Name of the created base DataVolume

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -54,7 +54,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 EOF
 ```
@@ -85,7 +85,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 EOF
 ```
@@ -114,7 +114,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 EOF
 ```

--- a/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -16,7 +16,7 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.18.0
+        value: v0.19.0
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -44,7 +44,7 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.18.0
+        value: v0.19.0
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -70,4 +70,4 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.18.0
+        value: v0.19.0

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: windows-customize
 spec:
   description: >-
@@ -75,7 +75,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       params:
         - name: manifest
           value: |-
@@ -145,7 +145,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       runAfter:
         - copy-vm-root-disk
     - name: wait-for-vmi-status
@@ -173,7 +173,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   finally:
     - name: cleanup-vm
       params:
@@ -196,7 +196,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   results:
     - name: baseDvName
       description: Name of the created base DataVolume

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -82,7 +82,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 EOF
 ```
@@ -115,7 +115,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
     timeout: 1h0m0s
 EOF

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -19,7 +19,7 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.18.0
+        value: v0.19.0
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -49,5 +49,5 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.18.0
+        value: v0.19.0
   timeout: 1h0m0s

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: windows-efi-installer
 spec:
   description: >-
@@ -98,7 +98,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
     - name: modify-windows-iso-file
       params:
         - name: pvcName
@@ -118,7 +118,7 @@ spec:
           - name: name
             value: modify-windows-iso-file
           - name: version
-            value: v0.18.0
+            value: v0.19.0
     - name: create-vm-root-disk
       taskRef:
         resolver: hub
@@ -132,7 +132,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       params:
         - name: manifest
           value: |-
@@ -214,7 +214,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: v0.18.0
+            value: v0.19.0
     - name: wait-for-vmi-status
       params:
         - name: vmiName
@@ -239,7 +239,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       timeout: 2h0m0s
     - name: create-base-dv
       params:
@@ -281,7 +281,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   finally:
     - name: cleanup-vm
       params:
@@ -303,7 +303,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: v0.18.0
+            value: v0.19.0
       timeout: 10m0s
     - name: delete-imported-iso
       params:
@@ -327,7 +327,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
     - name: delete-vm-rootdisk
       params:
         - name: deleteObject
@@ -350,7 +350,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.18.0
+            value: v0.19.0
   results:
     - description: Name of the created base DataVolume
       name: baseDvName

--- a/release/tasks/cleanup-vm/README.md
+++ b/release/tasks/cleanup-vm/README.md
@@ -77,7 +77,7 @@ spec:
         -   name: name
             value: cleanup-vm
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/release/tasks/cleanup-vm/cleanup-vm.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: cleanup-vm
 spec:
   description: >-
@@ -60,7 +60,7 @@ spec:
       default: ""
   steps:
     - name: execute-in-vm
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/cleanup-vm/examples/taskruns/cleanup-vm-taskrun-resolver.yaml
+++ b/release/tasks/cleanup-vm/examples/taskruns/cleanup-vm-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: cleanup-vm
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: vmName
       value: vm-example

--- a/release/tasks/copy-template/README.md
+++ b/release/tasks/copy-template/README.md
@@ -43,7 +43,7 @@ spec:
         -   name: name
             value: copy-template
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/copy-template/copy-template.yaml
+++ b/release/tasks/copy-template/copy-template.yaml
@@ -17,7 +17,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: copy-template
 spec:
   description: >-
@@ -51,7 +51,7 @@ spec:
       description: The namespace of a template that was created.
   steps:
     - name: copytemplate
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - copy-template
       args:

--- a/release/tasks/copy-template/examples/taskruns/copy-template-taskrun-resolver.yaml
+++ b/release/tasks/copy-template/examples/taskruns/copy-template-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: copy-template
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: sourceTemplateName
     value: source-vm-template-example

--- a/release/tasks/create-vm-from-manifest/README.md
+++ b/release/tasks/create-vm-from-manifest/README.md
@@ -38,7 +38,7 @@ spec:
         -   name: name
             value: create-vm-from-manifest
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: create-vm-from-manifest
 spec:
   description: >-
@@ -51,7 +51,7 @@ spec:
       description: The namespace of a VM that was created.
   steps:
     - name: createvm
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - create-vm
       args:

--- a/release/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun-resolver.yaml
+++ b/release/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: create-vm-from-manifest
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: manifest
     value: |

--- a/release/tasks/create-vm-from-template/README.md
+++ b/release/tasks/create-vm-from-template/README.md
@@ -49,7 +49,7 @@ spec:
         -   name: name
             value: create-vm-from-template
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/create-vm-from-template/create-vm-from-template.yaml
+++ b/release/tasks/create-vm-from-template/create-vm-from-template.yaml
@@ -17,7 +17,7 @@ metadata:
     artifacthub.io/category: integration-delivery
     tekton.dev/deprecated: "true"
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: create-vm-from-template
 spec:
   description: >-
@@ -55,7 +55,7 @@ spec:
       description: The namespace of a VM that was created.
   steps:
     - name: createvm
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - create-vm
       args:

--- a/release/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun-resolver.yaml
+++ b/release/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: create-vm-from-template
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: templateName
     value: vm-template-example

--- a/release/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
+++ b/release/tasks/create-vm-from-template/examples/taskruns/create-vm-from-template-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: create-vm-from-template
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: templateName
     value: vm-template-example

--- a/release/tasks/disk-virt-customize/README.md
+++ b/release/tasks/disk-virt-customize/README.md
@@ -34,7 +34,7 @@ spec:
         -   name: name
             value: disk-virt-customize
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/release/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: disk-virt-customize
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-customize
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.19.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: disk-virt-customize
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: pvc
       value: example-pvc

--- a/release/tasks/disk-virt-sysprep/README.md
+++ b/release/tasks/disk-virt-sysprep/README.md
@@ -34,7 +34,7 @@ spec:
         -   name: name
             value: disk-virt-sysprep
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: disk-virt-sysprep
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-sysprep
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.19.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: disk-virt-sysprep
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: pvc
       value: example-pvc

--- a/release/tasks/execute-in-vm/README.md
+++ b/release/tasks/execute-in-vm/README.md
@@ -67,7 +67,7 @@ spec:
         -   name: name
             value: execute-in-vm
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun-resolver.yaml
+++ b/release/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: execute-in-vm
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: vmName
       value: vm-example

--- a/release/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/release/tasks/execute-in-vm/execute-in-vm.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: execute-in-vm
 spec:
   description: >-
@@ -47,7 +47,7 @@ spec:
       default: ""
   steps:
     - name: execute-in-vm
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/generate-ssh-keys/README.md
+++ b/release/tasks/generate-ssh-keys/README.md
@@ -50,7 +50,7 @@ spec:
         -   name: name
             value: generate-ssh-keys
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun-resolver.yaml
+++ b/release/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: generate-ssh-keys
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: publicKeySecretName
       value: my-client-public-secret

--- a/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: generate-ssh-keys
 spec:
   description: >-
@@ -57,7 +57,7 @@ spec:
       description: The namespace of a private key secret.
   steps:
     - name: generate-ssh-keys
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/modify-data-object/README.md
+++ b/release/tasks/modify-data-object/README.md
@@ -42,7 +42,7 @@ spec:
         -   name: name
             value: modify-data-object
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun-resolver.yaml
+++ b/release/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: modify-data-object
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: waitForSuccess
       value: 'true'

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: modify-data-object
 spec:
   description: >-
@@ -57,7 +57,7 @@ spec:
       description: The namespace of the data object that was created.
   steps:
     - name: modify-data-object
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - modify-data-object
       args:

--- a/release/tasks/modify-vm-template/README.md
+++ b/release/tasks/modify-vm-template/README.md
@@ -62,7 +62,7 @@ spec:
         -   name: name
             value: modify-vm-template
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun-resolver.yaml
+++ b/release/tasks/modify-vm-template/examples/taskruns/modify-vm-template-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: modify-vm-template
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: templateName
     value: vm-template-example

--- a/release/tasks/modify-vm-template/modify-vm-template.yaml
+++ b/release/tasks/modify-vm-template/modify-vm-template.yaml
@@ -17,7 +17,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: modify-vm-template
 spec:
   description: >-
@@ -108,7 +108,7 @@ spec:
       description: The namespace of a template that was updated.
   steps:
     - name: modifyvmtemplate
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - modify-vm-template
       args:

--- a/release/tasks/modify-windows-iso-file/README.md
+++ b/release/tasks/modify-windows-iso-file/README.md
@@ -32,7 +32,7 @@ spec:
         -   name: name
             value: modify-windows-iso-file
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun-resolver.yaml
+++ b/release/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: modify-windows-iso-file
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
   - name: pvcName
     value: w11

--- a/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: modify-windows-iso-file
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.19.0"
       script: |
         #!/bin/bash
         set -x
@@ -84,7 +84,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       script: |
         #!/bin/bash
         set -ex
@@ -111,7 +111,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.19.0"
       script: |
         #!/bin/bash
         set -x

--- a/release/tasks/wait-for-vmi-status/README.md
+++ b/release/tasks/wait-for-vmi-status/README.md
@@ -36,7 +36,7 @@ spec:
         -   name: name
             value: wait-for-vmi-status
         -   name: version
-            value: v0.18.0
+            value: v0.19.0
         resolver: hub
 ```
 

--- a/release/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun-resolver.yaml
+++ b/release/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: wait-for-vmi-status
     - name: version
-      value: v0.18.0
+      value: v0.19.0
   params:
     - name: vmiName
       value: example-vm

--- a/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/version: v0.19.0
   name: wait-for-vmi-status
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       description: A label selector expression to decide if the VirtualMachineInstance (VMI) is in a failed state. Eg. "status.phase in (Failed, Unknown)". It is evaluated on each VMI update and will result in this task failing if true.
   steps:
     - name: wait-for-vmi-status
-      image: "quay.io/kubevirt/tekton-tasks:v0.18.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.19.0"
       command:
         - entrypoint
       env:

--- a/scripts/makefile-snippets/makefile-release.mk
+++ b/scripts/makefile-snippets/makefile-release.mk
@@ -1,2 +1,2 @@
 #current version of tekton tasks
-export RELEASE_VERSION ?=v0.18.0
+export RELEASE_VERSION ?=v0.19.0


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: bump version to v0.19.0

This commit bumps all versions of image to v0.19.0. This is necessary, because artifacthub takes files from GH tagged release and in case the images would not have newer version before release, release would contain older version

After this PR is merged, I will create new release which will push new containers to quay
**Release note**:
```
NONE
```
