### PR TITLE
fix: fix PipelineRun examples

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -62,7 +62,7 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-bios-installer
         -   name: version

--- a/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -15,7 +15,7 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-bios-installer
       - name: version

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -50,7 +50,7 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-customize
         -   name: version
@@ -81,7 +81,7 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-customize
         -   name: version
@@ -110,7 +110,7 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-customize
         -   name: version

--- a/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -12,7 +12,7 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-customize
       - name: version
@@ -40,7 +40,7 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-customize
       - name: version
@@ -66,7 +66,7 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-customize
       - name: version

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -78,12 +78,19 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-efi-installer
         -   name: version
             value: v0.19.0
         resolver: hub
+    taskRunSpecs:
+    -   pipelineTaskName: modify-windows-iso-file
+        podTemplate:
+            securityContext:
+                fsGroup: 1001
+                runAsGroup: 1001
+                runAsUser: 1001
 EOF
 ```
 ```yaml
@@ -111,12 +118,19 @@ spec:
         -   name: type
             value: artifact
         -   name: kind
-            value: task
+            value: pipeline
         -   name: name
             value: windows-efi-installer
         -   name: version
             value: v0.19.0
         resolver: hub
+    taskRunSpecs:
+    -   pipelineTaskName: modify-windows-iso-file
+        podTemplate:
+            securityContext:
+                fsGroup: 1001
+                runAsGroup: 1001
+                runAsUser: 1001
     timeout: 1h0m0s
 EOF
 ```

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -15,11 +15,18 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-efi-installer
       - name: version
         value: v0.19.0
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      podTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001   
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -45,9 +52,16 @@ spec:
       - name: type
         value: artifact
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: windows-efi-installer
       - name: version
         value: v0.19.0
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      podTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001     
   timeout: 1h0m0s

--- a/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -15,7 +15,7 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version

--- a/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -12,7 +12,7 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
@@ -40,7 +40,7 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
@@ -66,7 +66,7 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -15,11 +15,18 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
         value: {{ version }}
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      podTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001   
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -45,9 +52,16 @@ spec:
       - name: type
         value: {{ catalog_type }}
       - name: kind
-        value: task
+        value: pipeline
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
         value: {{ version }}
+  taskRunSpecs:
+    - pipelineTaskName: "modify-windows-iso-file"
+      podTemplate:
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001     
   timeout: 1h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: fix PipelineRun examples

this commit fixes wrong kind in pipelinerun and adds security context in efi pipelineruns. This is necessary when PipelineRun uses resolver. Then the modify-windows-iso-file task runs under different user and group.

**Release note**:
```
NONE
```
