### PR TITLE
fix: url of getisourl.py script in pipeline readmes

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -79,7 +79,7 @@ When a user defines a different namespace in e.g. `baseDvNamespace`, then the se
 
 #### Obtaining a download URL in an automated way
 
-The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/pipelines/windows-bios-installer/getisourl.py) can be used to automatically obtain a Windows 10 ISO download URL.
+The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/release/pipelines/windows-bios-installer/getisourl.py) can be used to automatically obtain a Windows 10 ISO download URL.
 
 The prerequisites are:
 

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -148,7 +148,7 @@ exist.
 
 #### Obtaining a download URL in an automated way
 
-The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/pipelines/windows-efi-installer/getisourl.py) can be used to automatically obtain a Windows 11 ISO download URL.
+The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/release/pipelines/windows-efi-installer/getisourl.py) can be used to automatically obtain a Windows 11 ISO download URL.
 
 The prerequisites are:
 

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -60,7 +60,7 @@ When a user defines a different namespace in e.g. `baseDvNamespace`, then the se
 
 #### Obtaining a download URL in an automated way
 
-The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/pipelines/windows-bios-installer/getisourl.py) can be used to automatically obtain a Windows 10 ISO download URL.
+The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/release/pipelines/windows-bios-installer/getisourl.py) can be used to automatically obtain a Windows 10 ISO download URL.
 
 The prerequisites are:
 

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -83,7 +83,7 @@ exist.
 
 #### Obtaining a download URL in an automated way
 
-The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/pipelines/windows-efi-installer/getisourl.py) can be used to automatically obtain a Windows 11 ISO download URL.
+The script [`getisourl.py`](https://github.com/kubevirt/kubevirt-tekton-tasks/blob/main/release/pipelines/windows-efi-installer/getisourl.py) can be used to automatically obtain a Windows 11 ISO download URL.
 
 The prerequisites are:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: url of getisourl.py script in pipeline readmes

**Release note**:
```
fix: url of getisourl.py script in pipeline readmes
```
