### PR TITLE
chore: enable setting catalog version without "v" prefix

### DIFF
--- a/scripts/ansible/common.yaml
+++ b/scripts/ansible/common.yaml
@@ -13,6 +13,8 @@ sa_name: "{{ role_name }}"
 role_binding_name: "{{ role_name }}"
 default_file_mode: "0644"
 version: "{{ lookup('env','RELEASE_VERSION')| default('latest', true) }}"
+remove_catalog_version_prefix: "{{ lookup('env','REMOVE_CATALOG_VERSION_PREFIX')| default(false) | bool}}"
+catalog_version: "{{ version[1:] if remove_catalog_version_prefix else version }}"
 
 windows10: windows10
 windows11: windows11

--- a/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
+++ b/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: windows-bios-installer
 spec:
   description: >-
@@ -79,7 +79,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -187,7 +187,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: create-vm-from-manifest
@@ -220,7 +220,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: wait-for-vmi-status
@@ -248,7 +248,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: cleanup-vm

--- a/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -19,4 +19,4 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}

--- a/templates-pipelines/windows-customize/manifests/windows-customize.yaml
+++ b/templates-pipelines/windows-customize/manifests/windows-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: windows-customize
 spec:
   description: >-
@@ -76,7 +76,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -151,7 +151,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: create-vm-from-manifest
@@ -184,7 +184,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: wait-for-vmi-status
@@ -212,7 +212,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: cleanup-vm

--- a/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -16,7 +16,7 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -44,7 +44,7 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -70,4 +70,4 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: windows-efi-installer
 spec:
   description: >-
@@ -99,7 +99,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -124,7 +124,7 @@ spec:
           - name: name
             value: modify-windows-iso-file
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-windows-iso-file
@@ -143,7 +143,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -230,7 +230,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: create-vm-from-manifest
@@ -260,7 +260,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: wait-for-vmi-status
@@ -307,7 +307,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -334,7 +334,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: cleanup-vm
@@ -363,7 +363,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object
@@ -391,7 +391,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: {{ version }}
+            value: {{ catalog_version }}
 {% else %}
         kind: Task
         name: modify-data-object

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -19,7 +19,7 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
@@ -56,7 +56,7 @@ spec:
       - name: name
         value: {{ item.pipeline_name }}
       - name: version
-        value: {{ version }}
+        value: {{ catalog_version }}
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:

--- a/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
+++ b/templates/cleanup-vm/examples/cleanup-vm-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: vmName
       value: vm-example

--- a/templates/copy-template/examples/copy-template-taskrun.yaml
+++ b/templates/copy-template/examples/copy-template-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
   - name: sourceTemplateName
     value: source-vm-template-example

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -17,7 +17,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
+++ b/templates/create-vm-from-manifest/examples/create-vm-from-manifest-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
   - name: manifest
     value: |

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -19,7 +19,7 @@ metadata:
     tekton.dev/deprecated: "true"
 {% endif %}
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
+++ b/templates/create-vm-from-template/examples/create-vm-from-template-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
   - name: templateName
     value: vm-template-example

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: pvc
       value: example-pvc

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: pvc
       value: example-pvc

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
+++ b/templates/execute-in-vm/examples/execute-in-vm-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: vmName
       value: vm-example

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
+++ b/templates/generate-ssh-keys/examples/generate-ssh-keys-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: publicKeySecretName
       value: my-client-public-secret

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
+++ b/templates/modify-data-object/examples/modify-data-object-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: waitForSuccess
       value: 'true'

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
+++ b/templates/modify-vm-template/examples/modify-vm-template-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
   - name: templateName
     value: vm-template-example

--- a/templates/modify-vm-template/manifests/modify-vm-template.yaml
+++ b/templates/modify-vm-template/manifests/modify-vm-template.yaml
@@ -17,7 +17,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
+++ b/templates/modify-windows-iso-file/examples/modify-windows-iso-file-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
   - name: pvcName
     value: w11

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-

--- a/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
+++ b/templates/wait-for-vmi-status/examples/wait-for-vmi-status-taskrun.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: {{ task_name }}
     - name: version
-      value: {{ version }}
+      value: {{ catalog_version }}
   params:
     - name: vmiName
       value: example-vm

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: {{ recommendation_url }}
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: {{ version }}
+    app.kubernetes.io/version: {{ catalog_version }}
   name: {{ task_name }}
 spec:
   description: >-


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: enable setting catalog version without "v" prefix
this commit allows to set REMOVE_CATALOG_VERSION_PREFIX env variable, which will remove "v" prefix from version in catalog version - e.g. 0.19.0 when true vs v0.19.0 when false.

This will help in DS where OCP catalog removes v from version. This commit also replaces all version variables from catalog version and replaces it with catalog_version which can hold version with or without v prefix

Signed-off-by: Karel Simon <ksimon@redhat.com>


**Release note**:
```
NONE
```
