### PR TITLE
chore: remove default value from baseDVNamespace and sourceDiskImageNamespace

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -42,6 +42,8 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespace than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline run with resolver:
 ```yaml
 export WIN_IMAGE_DOWNLOAD_URL=$(./getisourl.py) # see paragraph Obtaining a download URL in an automated way
@@ -55,6 +57,8 @@ spec:
     params:
     -   name: winImageDownloadURL
         value: ${WIN_IMAGE_DOWNLOAD_URL}
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     pipelineRef:
         params:
         -   name: catalog

--- a/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:

--- a/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
+++ b/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
@@ -63,7 +63,6 @@ spec:
     - name: baseDvNamespace
       description: Namespace of the base DataVolume which is created.
       type: string
-      default: kubevirt-os-images
   tasks:
     - name: create-vm-root-disk
       taskRef:

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -35,6 +35,8 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `sourceDiskImageNamespace` parameter with the namespace where the source PVC is located and `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespaces than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline runs with resolvers:
 ```yaml
 oc create -f - <<EOF
@@ -43,6 +45,11 @@ kind: PipelineRun
 metadata:
     generateName: windows11-customize-run-
 spec:
+    params:
+    -   name: sourceDiskImageNamespace
+        value: <source-disk-namespace>
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     pipelineRef:
         params:
         -   name: catalog
@@ -66,6 +73,10 @@ metadata:
     generateName: windows2k22-customize-run-
 spec:
     params:
+    -   name: sourceDiskImageNamespace
+        value: <source-disk-namespace>
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     -   name: sourceDiskImageName
         value: win2k22
     -   name: baseDvName
@@ -97,6 +108,10 @@ metadata:
     generateName: windows10-customize-run-
 spec:
     params:
+    -   name: sourceDiskImageNamespace
+        value: <source-disk-namespace>
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     -   name: sourceDiskImageName
         value: win10
     -   name: baseDvName

--- a/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -4,6 +4,11 @@ kind: PipelineRun
 metadata:
   generateName: windows11-customize-run-
 spec:
+  params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:
@@ -24,6 +29,10 @@ metadata:
   generateName: windows2k22-customize-run-
 spec:
   params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: sourceDiskImageName
       value: win2k22
     - name: baseDvName
@@ -52,6 +61,10 @@ metadata:
   generateName: windows10-customize-run-
 spec:
   params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: sourceDiskImageName
       value: win10
     - name: baseDvName

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -52,7 +52,6 @@ spec:
     - name: sourceDiskImageNamespace
       description: Namespace of the windows source disk which will be copied and modified with sysprep
       type: string
-      default: kubevirt-os-images
     - name: baseDvName
       description: Name of the result windows disk
       type: string
@@ -60,7 +59,6 @@ spec:
     - name: baseDvNamespace
       description: Namespace of the result windows disk
       type: string
-      default: kubevirt-os-images
   tasks:
     - name: copy-vm-root-disk
       taskRef:

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -58,6 +58,8 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespace than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline runs with resolvers:
 ```yaml
 export WIN_IMAGE_DOWNLOAD_URL=$(./getisourl.py) # see paragraph Obtaining a download URL in an automated way
@@ -71,6 +73,8 @@ spec:
     params:
     -   name: winImageDownloadURL
         value: ${WIN_IMAGE_DOWNLOAD_URL}
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     pipelineRef:
         params:
         -   name: catalog
@@ -101,6 +105,8 @@ metadata:
     generateName: windows2k22-installer-run-
 spec:
     params:
+    -   name: baseDvNamespace
+        value: <result-disk-namespace>
     -   name: winImageDownloadURL
         value: ${WIN_IMAGE_DOWNLOAD_URL}
     -   name: preferenceName

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:
@@ -34,6 +36,8 @@ metadata:
   generateName: windows2k22-installer-run-
 spec:
   params:
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
     - name: preferenceName

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -56,8 +56,7 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
-    - default: kubevirt-os-images
-      description: Namespace of the base DataVolume which is created.
+    - description: Namespace of the base DataVolume which is created.
       name: baseDvNamespace
       type: string
     - default: win11

--- a/scripts/ansible/variables.yaml
+++ b/scripts/ansible/variables.yaml
@@ -1,4 +1,3 @@
-os_image_namespace: kubevirt-os-images
 catalog: kubevirt-tekton-tasks
 catalog_type: artifact
 pipelines_catalog: kubevirt-tekton-pipelines

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -42,6 +42,8 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespace than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline run with resolver:
 {% for item in pipeline_runs_yaml %}
 ```yaml

--- a/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
+++ b/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
@@ -63,7 +63,6 @@ spec:
     - name: baseDvNamespace
       description: Namespace of the base DataVolume which is created.
       type: string
-      default: {{ os_image_namespace }}
   tasks:
     - name: create-vm-root-disk
       taskRef:

--- a/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-bios-installer/pipelineruns/pipelineruns.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -35,6 +35,8 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `sourceDiskImageNamespace` parameter with the namespace where the source PVC is located and `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespaces than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}
 ```yaml

--- a/templates-pipelines/windows-customize/manifests/windows-customize.yaml
+++ b/templates-pipelines/windows-customize/manifests/windows-customize.yaml
@@ -52,7 +52,6 @@ spec:
     - name: sourceDiskImageNamespace
       description: Namespace of the windows source disk which will be copied and modified with sysprep
       type: string
-      default: {{ os_image_namespace }}
     - name: baseDvName
       description: Name of the result windows disk
       type: string
@@ -60,7 +59,6 @@ spec:
     - name: baseDvNamespace
       description: Namespace of the result windows disk
       type: string
-      default: {{ os_image_namespace }}
   tasks:
     - name: copy-vm-root-disk
       taskRef:

--- a/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -4,6 +4,11 @@ kind: PipelineRun
 metadata:
   generateName: windows11-customize-run-
 spec:
+  params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:
@@ -24,6 +29,10 @@ metadata:
   generateName: windows2k22-customize-run-
 spec:
   params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: sourceDiskImageName
       value: win2k22
     - name: baseDvName
@@ -52,6 +61,10 @@ metadata:
   generateName: windows10-customize-run-
 spec:
   params:
+    - name: sourceDiskImageNamespace
+      value: <source-disk-namespace>
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: sourceDiskImageName
       value: win10
     - name: baseDvName

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -58,6 +58,8 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
 
+Update the `baseDvNamespace` parameter with the namespace where the result DataVolume should be created. In case you define different namespace than PipelineRun is created, please see #Usage in multiple namespaces paragraph.
+
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}
 ```yaml

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -56,8 +56,7 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
-    - default: {{ os_image_namespace }}
-      description: Namespace of the base DataVolume which is created.
+    - description: Namespace of the base DataVolume which is created.
       name: baseDvNamespace
       type: string
     - default: win11

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -7,6 +7,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
   pipelineRef:
     resolver: hub
     params:
@@ -34,6 +36,8 @@ metadata:
   generateName: windows2k22-installer-run-
 spec:
   params:
+    - name: baseDvNamespace
+      value: <result-disk-namespace>
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
     - name: preferenceName


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: remove default value from baseDVNamespace and sourceDiskImageNamespace in pipelines

Tekton probably contains bug, which does not propagate params from PipelineRuns, when resolver is defined. Instead it uses default values defined in pipeline manifest -
https://issues.redhat.com/browse/SRVKP-4329.
Hovewer if the param does not contain any default value, tekton passes correct value

**Release note**:
```
chore: remove default value from baseDVNamespace and sourceDiskImageNamespace in pipelines
```
