### PR TITLE
chore: add link to example configmaps for pipelines to README of each

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -41,6 +41,7 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps).
 
 Pipeline run with resolver:
 ```yaml

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -34,6 +34,7 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-customize/configmaps).
 
 Pipeline runs with resolvers:
 ```yaml

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -57,6 +57,7 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps).
 
 Pipeline runs with resolvers:
 ```yaml

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -41,6 +41,7 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps).
 
 Pipeline run with resolver:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -34,6 +34,7 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-customize/configmaps).
 
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -57,6 +57,7 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps).
 
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add link to example configmaps for pipelines to README of each pipeline

this commit adds a link to example configmaps for each pipeline in each pipeline's README.

**Release note**:
```
NONE
```
@akrejcir, @jcanocan, @0xFelix 