### PR TITLE
chore: remove namespace params from pipelines

### DIFF
--- a/automation/e2e-pipelines/test-files/windows10-customize-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows10-customize-pipelinerun.yaml
@@ -13,9 +13,5 @@ spec:
       value: win10-customized
     - name: preferenceName
       value: windows.10
-    - name: sourceDiskImageNamespace
-      value: kubevirt
-    - name: baseDvNamespace
-      value: kubevirt
   pipelineRef:
     name: windows-customize

--- a/automation/e2e-pipelines/test-files/windows10-installer-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows10-installer-pipelinerun.yaml
@@ -9,7 +9,5 @@ spec:
   params:
     - name: winImageDownloadURL
       value: http://http-server/disk.img
-    - name: baseDvNamespace
-      value: kubevirt
   pipelineRef:
     name: windows-bios-installer

--- a/automation/e2e-pipelines/test-files/windows11-customize-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows11-customize-pipelinerun.yaml
@@ -6,10 +6,5 @@ metadata:
   labels:
     pipelinerun: windows11-customize-run
 spec:
-  params:
-    - name: sourceDiskImageNamespace
-      value: kubevirt
-    - name: baseDvNamespace
-      value: kubevirt
   pipelineRef:
     name: windows-customize

--- a/automation/e2e-pipelines/test-files/windows2k22-customize-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows2k22-customize-pipelinerun.yaml
@@ -15,9 +15,5 @@ spec:
       value: windows.2k22
     - name: customizeConfigMapName
       value: windows-sqlserver
-    - name: sourceDiskImageNamespace
-      value: kubevirt
-    - name: baseDvNamespace
-      value: kubevirt
   pipelineRef:
     name: windows-customize

--- a/automation/e2e-pipelines/test-files/windows2k22-installer-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows2k22-installer-pipelinerun.yaml
@@ -17,7 +17,5 @@ spec:
       value: win2k22
     - name: isoDVName
       value: win2k22
-    - name: baseDvNamespace
-      value: kubevirt
   pipelineRef:
     name: windows-efi-installer

--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -71,10 +71,6 @@ spec:
 EOF
 ```
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Possible Optimizations
 
 #### Obtaining a download URL in an automated way

--- a/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
+++ b/release/pipelines/windows-bios-installer/windows-bios-installer.yaml
@@ -60,10 +60,6 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       type: string
       default: win10
-    - name: baseDvNamespace
-      description: Namespace of the base DataVolume which is created.
-      type: string
-      default: kubevirt-os-images
   tasks:
     - name: create-vm-root-disk
       taskRef:
@@ -91,7 +87,6 @@ spec:
                 "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
                 "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
               name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
             spec:
               storage:
                 resources:
@@ -113,7 +108,6 @@ spec:
             kind: VirtualMachine
             metadata:
               generateName: windows-bios-installer-
-              namespace: $(params.baseDvNamespace)
             spec:
               instancetype:
                 kind: $(params.instanceTypeKind)

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -119,10 +119,6 @@ spec:
 EOF
 ```
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Cancelling/Deleting PipelineRuns
 
 When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -49,18 +49,10 @@ spec:
       description: Name of the windows source disk which will be copied and modified with sysprep
       type: string
       default: win11
-    - name: sourceDiskImageNamespace
-      description: Namespace of the windows source disk which will be copied and modified with sysprep
-      type: string
-      default: kubevirt-os-images
     - name: baseDvName
       description: Name of the result windows disk
       type: string
       default: win11-customized
-    - name: baseDvNamespace
-      description: Namespace of the result windows disk
-      type: string
-      default: kubevirt-os-images
   tasks:
     - name: copy-vm-root-disk
       taskRef:
@@ -83,13 +75,12 @@ spec:
             kind: DataVolume
             metadata:
               name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
             spec:
               storage: {}
               source: 
                 pvc:
                   name: $(params.sourceDiskImageName)
-                  namespace: $(params.sourceDiskImageNamespace)
+                  namespace: $(context.pipelineRun.namespace)
         - name: waitForSuccess
           value: false
         - name: allowReplace
@@ -104,7 +95,6 @@ spec:
             kind: VirtualMachine
             metadata:
               generateName: windows-customize-
-              namespace: $(params.baseDvNamespace)
             spec:
               instancetype:
                 kind: $(params.instanceTypeKind)

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -135,10 +135,6 @@ spec:
 EOF
 ```
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Cancelling/Deleting PipelineRuns
 
 When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -56,10 +56,6 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
-    - default: kubevirt-os-images
-      description: Namespace of the base DataVolume which is created.
-      name: baseDvNamespace
-      type: string
     - default: win11
       description: Name of Windows ISO datavolume
       name: isoDVName
@@ -139,7 +135,12 @@ spec:
             apiVersion: cdi.kubevirt.io/v1beta1
             kind: DataVolume
             metadata:
-              generateName: windows-efi-root-disk-
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(params.baseDvName)
             spec:
               storage:
                 resources:
@@ -149,6 +150,8 @@ spec:
                 blank: {}
         - name: waitForSuccess
           value: false
+        - name: allowReplace
+          value: true
     - name: create-vm
       params:
         - name: runStrategy
@@ -241,47 +244,6 @@ spec:
           - name: version
             value: v0.19.0
       timeout: 2h0m0s
-    - name: create-base-dv
-      params:
-        - name: manifest
-          value: |
-            apiVersion: cdi.kubevirt.io/v1beta1
-            kind: DataVolume
-            metadata:
-              annotations:
-                "cdi.kubevirt.io/storage.bind.immediate.requested": "true"
-              labels:
-                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
-                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
-                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
-                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
-              name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
-            spec:
-              storage: {}
-              source:
-                pvc:
-                  name: $(tasks.create-vm-root-disk.results.name)
-                  namespace: $(tasks.create-vm-root-disk.results.namespace)
-        - name: waitForSuccess
-          value: true
-        - name: allowReplace
-          value: true
-      runAfter:
-        - wait-for-vmi-status
-      taskRef:
-        resolver: hub
-        params:
-          - name: catalog
-            value: kubevirt-tekton-tasks
-          - name: type
-            value: artifact
-          - name: kind
-            value: task
-          - name: name
-            value: modify-data-object
-          - name: version
-            value: v0.19.0
   finally:
     - name: cleanup-vm
       params:
@@ -328,33 +290,10 @@ spec:
             value: modify-data-object
           - name: version
             value: v0.19.0
-    - name: delete-vm-rootdisk
-      params:
-        - name: deleteObject
-          value: true
-        - name: deleteObjectKind
-          value: DataVolume
-        - name: deleteObjectName
-          value: $(tasks.create-vm-root-disk.results.name)
-        - name: namespace
-          value: $(tasks.create-vm-root-disk.results.namespace)
-      taskRef:
-        resolver: hub
-        params:
-          - name: catalog
-            value: kubevirt-tekton-tasks
-          - name: type
-            value: artifact
-          - name: kind
-            value: task
-          - name: name
-            value: modify-data-object
-          - name: version
-            value: v0.19.0
   results:
     - description: Name of the created base DataVolume
       name: baseDvName
-      value: $(tasks.create-base-dv.results.name)
+      value: $(tasks.create-vm-root-disk.results.name)
     - description: Namespace of the created base DataVolume
       name: baseDvNamespace
-      value: $(tasks.create-base-dv.results.namespace)
+      value: $(tasks.create-vm-root-disk.results.namespace)

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -52,10 +52,6 @@ oc create -f - <<EOF
 ```
 {% endfor %}
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Possible Optimizations
 
 #### Obtaining a download URL in an automated way

--- a/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
+++ b/templates-pipelines/windows-bios-installer/manifests/windows-bios-installer.yaml
@@ -60,10 +60,6 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       type: string
       default: win10
-    - name: baseDvNamespace
-      description: Namespace of the base DataVolume which is created.
-      type: string
-      default: {{ os_image_namespace }}
   tasks:
     - name: create-vm-root-disk
       taskRef:
@@ -96,7 +92,6 @@ spec:
                 "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
                 "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
               name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
             spec:
               storage:
                 resources:
@@ -118,7 +113,6 @@ spec:
             kind: VirtualMachine
             metadata:
               generateName: windows-bios-installer-
-              namespace: $(params.baseDvNamespace)
             spec:
               instancetype:
                 kind: $(params.instanceTypeKind)

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -43,10 +43,6 @@ oc create -f - <<EOF
 ```
 {% endfor %}
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Cancelling/Deleting PipelineRuns
 
 When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.

--- a/templates-pipelines/windows-customize/manifests/windows-customize.yaml
+++ b/templates-pipelines/windows-customize/manifests/windows-customize.yaml
@@ -49,18 +49,10 @@ spec:
       description: Name of the windows source disk which will be copied and modified with sysprep
       type: string
       default: win11
-    - name: sourceDiskImageNamespace
-      description: Namespace of the windows source disk which will be copied and modified with sysprep
-      type: string
-      default: {{ os_image_namespace }}
     - name: baseDvName
       description: Name of the result windows disk
       type: string
       default: win11-customized
-    - name: baseDvNamespace
-      description: Namespace of the result windows disk
-      type: string
-      default: {{ os_image_namespace }}
   tasks:
     - name: copy-vm-root-disk
       taskRef:
@@ -88,13 +80,12 @@ spec:
             kind: DataVolume
             metadata:
               name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
             spec:
               storage: {}
               source: 
                 pvc:
                   name: $(params.sourceDiskImageName)
-                  namespace: $(params.sourceDiskImageNamespace)
+                  namespace: $(context.pipelineRun.namespace)
         - name: waitForSuccess
           value: false
         - name: allowReplace
@@ -109,7 +100,6 @@ spec:
             kind: VirtualMachine
             metadata:
               generateName: windows-customize-
-              namespace: $(params.baseDvNamespace)
             spec:
               instancetype:
                 kind: $(params.instanceTypeKind)

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -70,10 +70,6 @@ oc create -f - <<EOF
 ```
 {% endfor %}
 
-### Usage in multiple namespaces
-
-When a user defines a different namespace in e.g. `baseDvNamespace`, then the serviceAccount under which the Pipeline is running will require additional permissions in that namespace. Required permissions to run Task in different namespace can be found in README of each Task.
-
 ## Cancelling/Deleting PipelineRuns
 
 When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -56,10 +56,6 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
-    - default: {{ os_image_namespace }}
-      description: Namespace of the base DataVolume which is created.
-      name: baseDvNamespace
-      type: string
     - default: win11
       description: Name of Windows ISO datavolume
       name: isoDVName
@@ -154,7 +150,12 @@ spec:
             apiVersion: cdi.kubevirt.io/v1beta1
             kind: DataVolume
             metadata:
-              generateName: windows-efi-root-disk-
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(params.baseDvName)
             spec:
               storage:
                 resources:
@@ -164,6 +165,8 @@ spec:
                 blank: {}
         - name: waitForSuccess
           value: false
+        - name: allowReplace
+          value: true
     - name: create-vm
       params:
         - name: runStrategy
@@ -266,52 +269,6 @@ spec:
         name: wait-for-vmi-status
 {% endif %}
       timeout: 2h0m0s
-    - name: create-base-dv
-      params:
-        - name: manifest
-          value: |
-            apiVersion: cdi.kubevirt.io/v1beta1
-            kind: DataVolume
-            metadata:
-              annotations:
-                "cdi.kubevirt.io/storage.bind.immediate.requested": "true"
-              labels:
-                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
-                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
-                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
-                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
-              name: $(params.baseDvName)
-              namespace: $(params.baseDvNamespace)
-            spec:
-              storage: {}
-              source:
-                pvc:
-                  name: $(tasks.create-vm-root-disk.results.name)
-                  namespace: $(tasks.create-vm-root-disk.results.namespace)
-        - name: waitForSuccess
-          value: true
-        - name: allowReplace
-          value: true
-      runAfter:
-        - wait-for-vmi-status
-      taskRef:
-{% if use_resolver_in_manifests %}
-        resolver: hub
-        params:
-          - name: catalog
-            value: {{ catalog }}
-          - name: type
-            value: {{ catalog_type }}
-          - name: kind
-            value: task
-          - name: name
-            value: modify-data-object
-          - name: version
-            value: {{ catalog_version }}
-{% else %}
-        kind: Task
-        name: modify-data-object
-{% endif %}
   finally:
     - name: cleanup-vm
       params:
@@ -368,38 +325,10 @@ spec:
         kind: Task
         name: modify-data-object
 {% endif %}
-    - name: delete-vm-rootdisk
-      params:
-        - name: deleteObject
-          value: true
-        - name: deleteObjectKind
-          value: DataVolume
-        - name: deleteObjectName
-          value: $(tasks.create-vm-root-disk.results.name)
-        - name: namespace
-          value: $(tasks.create-vm-root-disk.results.namespace)
-      taskRef:
-{% if use_resolver_in_manifests %}
-        resolver: hub
-        params:
-          - name: catalog
-            value: {{ catalog }}
-          - name: type
-            value: {{ catalog_type }}
-          - name: kind
-            value: task
-          - name: name
-            value: modify-data-object
-          - name: version
-            value: {{ catalog_version }}
-{% else %}
-        kind: Task
-        name: modify-data-object
-{% endif %}
   results:
     - description: Name of the created base DataVolume
       name: baseDvName
-      value: $(tasks.create-base-dv.results.name)
+      value: $(tasks.create-vm-root-disk.results.name)
     - description: Namespace of the created base DataVolume
       name: baseDvNamespace
-      value: $(tasks.create-base-dv.results.namespace)
+      value: $(tasks.create-vm-root-disk.results.namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: remove namespace params from pipelines
Since the regular users doesn't normally have access to different namespaces, multi namespace use case doesn't make sense. And since we want to have the pipelines as simple as possible, the multi namespace use case adds a lot of complexity with creating RBAC objects and correctly binding them to pipelines.

**Release note**:
```
chore: remove namespace params from pipelines
```
