### PR TITLE
fix: readme of windows efi installer pipeline

### DIFF
--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -40,7 +40,7 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## Pipeline Description
 
 ```
-  import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- create-base-dv --- cleanup-vm
+  import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- cleanup-vm
                                               |
                        create-vm-root-disk --- 
 ```
@@ -50,9 +50,8 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 3. `modify-windows-iso-file` extracts imported ISO file, replaces prompt bootloader (which is used as a default one when EFI is used) with no-prompt bootloader, pack the updated files back to new ISO, convert the ISO and replaces original ISO with updated one.Replacement of bootloader is needed to be able to automate installation of Windows versions which require EFI.
 4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the DataVolume with the ISO file. In case you would like to run the VirtualMachine in a different namespace, both Datavolumes have to be copied to the same namespace as the VirtualMachine.
 5. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
-6. `create-base-dv` Task creates an DataVolume with the specified name and namespace (Pipeline parameters `baseDvName` and `baseDvNamespace`). Then it clones the second DataVolume of the installation VirtualMachine into the new DataVolume.
-7. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
-8. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
+6. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
+7. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
 

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -40,7 +40,7 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## Pipeline Description
 
 ```
-  import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- create-base-dv --- cleanup-vm
+  import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- cleanup-vm
                                               |
                        create-vm-root-disk --- 
 ```
@@ -50,9 +50,8 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 3. `modify-windows-iso-file` extracts imported ISO file, replaces prompt bootloader (which is used as a default one when EFI is used) with no-prompt bootloader, pack the updated files back to new ISO, convert the ISO and replaces original ISO with updated one.Replacement of bootloader is needed to be able to automate installation of Windows versions which require EFI.
 4. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the DataVolume with the ISO file. In case you would like to run the VirtualMachine in a different namespace, both Datavolumes have to be copied to the same namespace as the VirtualMachine.
 5. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
-6. `create-base-dv` Task creates an DataVolume with the specified name and namespace (Pipeline parameters `baseDvName` and `baseDvNamespace`). Then it clones the second DataVolume of the installation VirtualMachine into the new DataVolume.
-7. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
-8. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
+6. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
+7. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
 
 ## How to run
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: readme of windows efi installer pipeline

One step was removed from pipeline and README has to be adjusted

**Release note**:
```
fix: readme of windows efi installer pipeline
```
