### PR TITLE
chore: download bootsources from quay instead of dockerhub

### DIFF
--- a/modules/sharedtest/testobjects/alpine-vm.go
+++ b/modules/sharedtest/testobjects/alpine-vm.go
@@ -24,12 +24,12 @@ func NewTestAlpineVM(name string) *TestVM {
 			Name: containerDiskName,
 			VolumeSource: v1.VolumeSource{
 				ContainerDisk: &v1.ContainerDiskSource{
-					Image: "kubevirt/alpine-container-disk-demo:latest",
+					Image: "quay.io/kubevirt/alpine-container-disk-demo:20240426_ca94b81c6",
 				},
 			},
 		},
 	}
 	return (&TestVM{
 		Data: newRandomVirtualMachine(vmi, false),
-	}).WithMemory("64Mi")
+	}).WithMemory("128Mi")
 }

--- a/modules/sharedtest/testobjects/fedora-cloud-vm.go
+++ b/modules/sharedtest/testobjects/fedora-cloud-vm.go
@@ -50,5 +50,5 @@ func NewTestFedoraCloudVM(name string) *TestVM {
 	}
 	return (&TestVM{
 		Data: newRandomVirtualMachine(vmi, false),
-	}).WithMemory("512Mi")
+	}).WithMemory("1Gi")
 }

--- a/modules/sharedtest/testobjects/template/cirros-tiny.go
+++ b/modules/sharedtest/testobjects/template/cirros-tiny.go
@@ -79,7 +79,7 @@ objects:
               rng: {}
             resources:
               requests:
-                memory: 64Mi
+                memory: 128Mi
           networks:
             - name: default
               pod: {}
@@ -87,7 +87,7 @@ objects:
           volumes:
             - name: containerdisk
               containerDisk:
-                image: 'kubevirt/cirros-container-disk-demo:latest'
+                image: 'quay.io/kubevirt/cirros-container-disk-demo:20240426_ca94b81c6'
             - name: cloudinitdisk
               cloudInitNoCloud:
                 userData: |

--- a/test/disk_virt_libguestfs_tasks_test.go
+++ b/test/disk_virt_libguestfs_tasks_test.go
@@ -114,8 +114,8 @@ var _ = Describe("Run disk virt-customize / virt-sysprep", func() {
 				},
 				TaskData: testconfigs.DiskVirtLibguestfsTaskData{
 					Datavolume: datavolume.NewBlankDataVolume("basic-functionality").
-						WithSize(5, resource.Giga).
-						WithRegistrySource("docker://kubevirt/fedora-cloud-registry-disk-demo").
+						WithSize(15, resource.Giga).
+						WithRegistrySource("docker://quay.io/containerdisks/centos-stream:9-latest").
 						Build(),
 					Commands:           customizeCommand,
 					LibguestfsTaskType: taskType,


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: download bootsources from quay instead of dockerhub in e2e tests

increase memory requirements for VMs

**Release note**:
```
chore: download bootsources from quay instead of dockerhub in e2e tests
```
