### PR TITLE
chore: disable AcceptEula tag in autounattend.xml ConfigMaps

### DIFF
--- a/release/pipelines/windows-bios-installer/README.md
+++ b/release/pipelines/windows-bios-installer/README.md
@@ -41,7 +41,10 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
-Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps).
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps). Before applying ConfigMap, uncomment the lines with `<AcceptEula>true<\/AcceptEula>`, or run this command:
+```
+sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "configmaps/windows-bios-installer-configmaps.yaml"
+```
 
 Pipeline run with resolver:
 ```yaml

--- a/release/pipelines/windows-bios-installer/configmaps/windows-bios-installer-configmaps.yaml
+++ b/release/pipelines/windows-bios-installer/configmaps/windows-bios-installer-configmaps.yaml
@@ -65,7 +65,7 @@ data:
             </OSImage>
           </ImageInstall>
           <UserData>
-            <AcceptEula>true</AcceptEula>
+            <!-- <AcceptEula>true</AcceptEula> -->
             <ProductKey>
               <Key/>
             </ProductKey>

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -56,7 +56,10 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
-Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps).
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps). Before applying ConfigMap, uncomment the lines with `<AcceptEula>true<\/AcceptEula>`, or run this command:
+```
+sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "configmaps/windows-efi-installer-configmaps.yaml"
+```
 
 Pipeline runs with resolvers:
 ```yaml

--- a/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -98,7 +98,7 @@ data:
             </OSImage>
           </ImageInstall>
           <UserData>
-            <AcceptEula>true</AcceptEula>
+            <!-- <AcceptEula>true</AcceptEula> -->
             <ProductKey>
               <Key/>
             </ProductKey>

--- a/scripts/deploy-pipelines.sh
+++ b/scripts/deploy-pipelines.sh
@@ -10,6 +10,8 @@ USE_RESOLVER_IN_MANIFESTS=false make generate-pipelines
 visit "${REPO_DIR}/release/pipelines"
     for PIPELINE_NAME in "windows-efi-installer" "windows-customize" "windows-bios-installer"; do
         oc apply -f "${PIPELINE_NAME}/${PIPELINE_NAME}.yaml"
+        # uncomment accepting eula in autounattend.xml
+        sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "${PIPELINE_NAME}/configmaps/${PIPELINE_NAME}-configmaps.yaml"
         oc apply -f "${PIPELINE_NAME}/configmaps"
     done
 leave

--- a/templates-pipelines/windows-bios-installer/README.md
+++ b/templates-pipelines/windows-bios-installer/README.md
@@ -41,7 +41,10 @@ The Pipeline implements this by spinning up a new VirtualMachine which boots fro
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
-Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps).
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-bios-installer/configmaps). Before applying ConfigMap, uncomment the lines with `<AcceptEula>true<\/AcceptEula>`, or run this command:
+```
+sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "configmaps/windows-bios-installer-configmaps.yaml"
+```
 
 Pipeline run with resolver:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-bios-installer/configmaps/windows-bios-installer-configmaps.yaml
+++ b/templates-pipelines/windows-bios-installer/configmaps/windows-bios-installer-configmaps.yaml
@@ -65,7 +65,7 @@ data:
             </OSImage>
           </ImageInstall>
           <UserData>
-            <AcceptEula>true</AcceptEula>
+            <!-- <AcceptEula>true</AcceptEula> -->
             <ProductKey>
               <Key/>
             </ProductKey>

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -56,7 +56,10 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## How to run
 
 Before you create PipelineRuns, you must create ConfigMaps with an autounattend.xml in the same namespace in which the VirtualMachine will be created.
-Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps).
+Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-efi-installer/configmaps). Before applying ConfigMap, uncomment the lines with `<AcceptEula>true<\/AcceptEula>`, or run this command:
+```
+sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "configmaps/windows-efi-installer-configmaps.yaml"
+```
 
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}

--- a/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -98,7 +98,7 @@ data:
             </OSImage>
           </ImageInstall>
           <UserData>
-            <AcceptEula>true</AcceptEula>
+            <!-- <AcceptEula>true</AcceptEula> -->
             <ProductKey>
               <Key/>
             </ProductKey>


### PR DESCRIPTION
**What this PR does / why we need it**:
disable AcceptEula tag in autounattend.xml ConfigMaps

Before running pipelines, users should uncomment the AcceptEula tag in ConfigMaps containing autounattend.xml

**Release note**:
```
Disable AcceptEula tag in autounattend.xml ConfigMaps

```
