### PR TITLE
fix: set RunAsUser and fsGroup for disk-virt tests

### DIFF
--- a/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
+++ b/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
@@ -3,7 +3,9 @@ package testconfigs
 import (
 	. "github.com/kubevirt/kubevirt-tekton-tasks/test/constants"
 	"github.com/kubevirt/kubevirt-tekton-tasks/test/framework/testoptions"
+	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	pipev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
@@ -98,7 +100,7 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *pi
 		})
 		taskName = DiskVirtCustomizeTaskName
 	}
-
+	var qemuUser int64 = 107
 	return &pipev1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      E2ETestsRandomName("taskrun-disk-" + string(c.TaskData.LibguestfsTaskType) + nameSuffix),
@@ -111,6 +113,12 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *pi
 			},
 			Timeout: &metav1.Duration{Duration: c.GetTaskRunTimeout()},
 			Params:  params,
+			PodTemplate: &pod.PodTemplate{
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsUser: &qemuUser,
+					FSGroup:   &qemuUser,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: set RunAsUser and fsGroup for disk-virt tests

Some clusters can set wrong UID, GID for mounted PVCs. That might cause issues, that PVC is inaccessible for disk-virt binary. This commit updates disk-virt tests to set up RunAsUser and FSGroup attributes with id 107, the same as is used for disks inside PVC. That will make sure the disks are accessible by disk-virt binaries

**Release note**:
```
NONE
```
