### PR TITLE
chore: improve error message in modify-windows-iso and README.md

### DIFF
--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -8,6 +8,11 @@ This example Pipeline is suitable only for Windows 11 or Server 2k22 (or other W
 The Pipeline implements this by modifying the supplied Windows ISO. It extracts all files from the ISO, replaces the prompt bootloader with the no-prompt bootloader and creates a new bootable ISO.
 This helps with automated installation of Windows in EFI boot mode. By default Windows in EFI boot mode uses a prompt bootloader, which will not continue with the boot process until a key is pressed. By replacing it with the no-prompt bootloader no key press is required to boot into the Windows installer. Then Task packs updated packages to new ISO, converts it with qemu-img and replaces original ISO file in PVC.
 
+> [!IMPORTANT]
+> If the ISO file does not contain files `efisys_noprompt.bin` and `cdboot_noprompt.efi` located at `efi/microsoft/boot/` 
+> inside ISO file, the `modify-windows-iso-file` task will exit and whole Pipeline will fail. In case your ISO file has 
+> different file structure, update `modify-windows-iso-file` task accordingly.
+
 After the ISO is modified it creates a new VirtualMachine which boots from the modified Windows installation image (ISO file). The installation of Windows is automatically executed and controlled by a Windows answer file. Then the Pipeline will wait for the installation to complete and will delete the created VirtualMachine while keeping the resulting DataVolume with the installed operating system. The Pipeline can be customized to support different installation requirements.
 
 ## Prerequisites

--- a/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -52,7 +52,9 @@ spec:
         guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
 
         if [ ! -f ${EFI_BOOT}/efisys_noprompt.bin ] || [ ! -f ${EFI_BOOT}/cdboot_noprompt.efi ]; then
-          echo "${EFI_BOOT}/efisys_noprompt.bin or ${EFI_BOOT}/cdboot_noprompt.efi not found in the iso file! Exiting"
+          echo "${EFI_BOOT}/efisys_noprompt.bin or ${EFI_BOOT}/cdboot_noprompt.efi not found in the iso file! Task expects that ISO file contains bootloader without prompt. If the no prompt bootloader is not present, the installation might behave unexpectedly. Exiting"
+          echo "ISO file checksum:" $(sha256sum ${TARGET_IMG_FILE_PATH})
+          ls -la ${TARGET_IMG_FILE_PATH}
           exit 1
         fi
 

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -8,6 +8,11 @@ This example Pipeline is suitable only for Windows 11 or Server 2k22 (or other W
 The Pipeline implements this by modifying the supplied Windows ISO. It extracts all files from the ISO, replaces the prompt bootloader with the no-prompt bootloader and creates a new bootable ISO.
 This helps with automated installation of Windows in EFI boot mode. By default Windows in EFI boot mode uses a prompt bootloader, which will not continue with the boot process until a key is pressed. By replacing it with the no-prompt bootloader no key press is required to boot into the Windows installer. Then Task packs updated packages to new ISO, converts it with qemu-img and replaces original ISO file in PVC.
 
+> [!IMPORTANT]
+> If the ISO file does not contain files `efisys_noprompt.bin` and `cdboot_noprompt.efi` located at `efi/microsoft/boot/` 
+> inside ISO file, the `modify-windows-iso-file` task will exit and whole Pipeline will fail. In case your ISO file has 
+> different file structure, update `modify-windows-iso-file` task accordingly.
+
 After the ISO is modified it creates a new VirtualMachine which boots from the modified Windows installation image (ISO file). The installation of Windows is automatically executed and controlled by a Windows answer file. Then the Pipeline will wait for the installation to complete and will delete the created VirtualMachine while keeping the resulting DataVolume with the installed operating system. The Pipeline can be customized to support different installation requirements.
 
 ## Prerequisites

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -52,7 +52,9 @@ spec:
         guestfish -a ${TARGET_IMG_FILE_PATH} -m /dev/sda tar-out / - | tar xvf - -C ${ISO_FILES_PATH} -m --no-overwrite-dir --owner=$(id -u) --group=$(id -g) --no-same-permissions
 
         if [ ! -f ${EFI_BOOT}/efisys_noprompt.bin ] || [ ! -f ${EFI_BOOT}/cdboot_noprompt.efi ]; then
-          echo "${EFI_BOOT}/efisys_noprompt.bin or ${EFI_BOOT}/cdboot_noprompt.efi not found in the iso file! Exiting"
+          echo "${EFI_BOOT}/efisys_noprompt.bin or ${EFI_BOOT}/cdboot_noprompt.efi not found in the iso file! Task expects that ISO file contains bootloader without prompt. If the no prompt bootloader is not present, the installation might behave unexpectedly. Exiting"
+          echo "ISO file checksum:" $(sha256sum ${TARGET_IMG_FILE_PATH})
+          ls -la ${TARGET_IMG_FILE_PATH}
           exit 1
         fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: improve error message in modify-windows-iso and README.md
the task expect ISO in some format. Improve the error message to indicate user, that task will not work without correct ISO file. Add command to generate sha256 checksum of the file.

**Release note**:
```
NONE
```
