### PR TITLE
fix: folders in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/dist/
-.idea/
+./.idea/
 ah
-manifests
-test/test.test
+/manifests/
+/test/test.test


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: folders in gitignore
Fix rules to ignore folder manifests and .idea only in the root of the project

**Release note**:
```
NONE
```
