### PR TITLE
fix: allowReplace param for datasource in modify-data-object task

### DIFF
--- a/modules/modify-data-object/pkg/dataobject/provider.go
+++ b/modules/modify-data-object/pkg/dataobject/provider.go
@@ -124,7 +124,7 @@ func (d *dataObjectProvider) deleteOldObject(helper *resource.Helper, obj *unstr
 	}
 
 	_, err = helper.Delete(namespace, name)
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: allowReplace param for datasource in modify-data-object task

when datasource does not exists and allowReplace param is set to true, the task fails, because it could not find the object. This commit adds check if the error returned is notFound and if yes, do not return the error

**Release note**:
```
fix: allowReplace param for datasource in modify-data-object task
```
