### PR TITLE
fix: release version in scripts/makefile-snippets/makefile-release.mk

### DIFF
--- a/scripts/makefile-snippets/makefile-release.mk
+++ b/scripts/makefile-snippets/makefile-release.mk
@@ -1,2 +1,2 @@
 #current version of tekton tasks
-export RELEASE_VERSION ?=v0.19.0
+export RELEASE_VERSION ?=v0.20.0


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: release version in scripts/makefile-snippets/makefile-release.mk

**Release note**:
```
NONE
```
