### PR TITLE
fix: create-vm task if VMI manifest is used

### DIFF
--- a/modules/create-vm/pkg/vm/vm.go
+++ b/modules/create-vm/pkg/vm/vm.go
@@ -10,7 +10,12 @@ import (
 )
 
 func AddMetadata(vm *kubevirtv1.VirtualMachine, template *templatev1.Template) {
-	tempLabels := k8s.EnsureLabels(&vm.Spec.Template.ObjectMeta)
+	var tempLabels map[string]string
+	if vm.Spec.Template == nil {
+		tempLabels = k8s.EnsureLabels(&vm.ObjectMeta)
+	} else {
+		tempLabels = k8s.EnsureLabels(&vm.Spec.Template.ObjectMeta)
+	}
 
 	if template != nil {
 		labels := k8s.EnsureLabels(&vm.ObjectMeta)


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: create-vm task if VMI manifest is used

when VMI manifest does not contain spec.template.objectMeta, the task failed, due to nil pointer. This fix checks if objectMeta exists and if not, use VMI objectMeta instead

**Release note**:
```
fix: create-vm task if VMI manifest is used
```
