### PR TITLE
fix: remove bios pipeline leftover from deploy-pipelines.sh script

### DIFF
--- a/scripts/deploy-pipelines.sh
+++ b/scripts/deploy-pipelines.sh
@@ -8,7 +8,7 @@ source "./scripts/common.sh"
 USE_RESOLVER_IN_MANIFESTS=false make generate-pipelines
 
 visit "${REPO_DIR}/release/pipelines"
-    for PIPELINE_NAME in "windows-efi-installer" "windows-customize" "windows-bios-installer"; do
+    for PIPELINE_NAME in "windows-efi-installer" "windows-customize"; do
         oc apply -f "${PIPELINE_NAME}/${PIPELINE_NAME}.yaml"
         # uncomment accepting eula in autounattend.xml
         sed -i "s/<!-- <AcceptEula>true<\/AcceptEula> -->/<AcceptEula>true<\/AcceptEula>/g" "${PIPELINE_NAME}/configmaps/${PIPELINE_NAME}-configmaps.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: remove bios pipeline leftover from deploy-pipelines.sh script

**Release note**:
```
NONE
```
