### PR TITLE
chore: change all preferences to use virtio in pipelines

### DIFF
--- a/automation/e2e-pipelines/test-files/windows10-customize-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows10-customize-pipelinerun.yaml
@@ -12,6 +12,6 @@ spec:
     - name: baseDvName
       value: win10-customized
     - name: preferenceName
-      value: windows.10
+      value: windows.10.virtio
   pipelineRef:
     name: windows-customize

--- a/automation/e2e-pipelines/test-files/windows10-installer-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows10-installer-pipelinerun.yaml
@@ -10,7 +10,7 @@ spec:
     - name: winImageDownloadURL
       value: http://http-server/disk.img
     - name: preferenceName
-      value: windows.10
+      value: windows.10.virtio
     - name: autounattendConfigMapName
       value: windows10-efi-autounattend
     - name: baseDvName

--- a/automation/e2e-pipelines/test-files/windows2k22-customize-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows2k22-customize-pipelinerun.yaml
@@ -12,7 +12,7 @@ spec:
     - name: baseDvName
       value: win2k22-customized
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: customizeConfigMapName
       value: windows-sqlserver
   pipelineRef:

--- a/automation/e2e-pipelines/test-files/windows2k22-installer-pipelinerun.yaml
+++ b/automation/e2e-pipelines/test-files/windows2k22-installer-pipelinerun.yaml
@@ -10,7 +10,7 @@ spec:
     - name: winImageDownloadURL
       value: http://http-server/disk.img
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: autounattendConfigMapName
       value: windows2k22-autounattend
     - name: baseDvName

--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -72,7 +72,7 @@ spec:
     -   name: baseDvName
         value: win2k22-customized
     -   name: preferenceName
-        value: windows.2k22
+        value: windows.2k22.virtio
     -   name: customizeConfigMapName
         value: windows-sqlserver
     pipelineRef:
@@ -103,7 +103,7 @@ spec:
     -   name: baseDvName
         value: win10-customized
     -   name: preferenceName
-        value: windows.10
+        value: windows.10.virtio
     pipelineRef:
         params:
         -   name: catalog

--- a/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -29,7 +29,7 @@ spec:
     - name: baseDvName
       value: win2k22-customized
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: customizeConfigMapName
       value: windows-sqlserver
   pipelineRef:
@@ -57,7 +57,7 @@ spec:
     - name: baseDvName
       value: win10-customized
     - name: preferenceName
-      value: windows.10
+      value: windows.10.virtio
   pipelineRef:
     resolver: hub
     params:

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -36,7 +36,7 @@ spec:
     - name: preferenceName
       type: string
       description: Name of VirtualMachineClusterPreference object
-      default: windows.11
+      default: windows.11.virtio
     - name: virtualMachinePreferenceKind
       type: string
       description: Kind of virtualMachinePreference object

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -158,7 +158,7 @@ spec:
     -   name: winImageDownloadURL
         value: ${WIN_IMAGE_DOWNLOAD_URL}
     -   name: preferenceName
-        value: windows.2k22
+        value: windows.2k22.virtio
     -   name: autounattendConfigMapName
         value: windows2k22-autounattend
     -   name: baseDvName

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -75,7 +75,7 @@ spec:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: autounattendConfigMapName
       value: windows2k22-autounattend
     - name: baseDvName

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -39,7 +39,7 @@ spec:
     - name: preferenceName
       type: string
       description: Name of VirtualMachineClusterPreference object
-      default: windows.11
+      default: windows.11.virtio
     - name: virtualMachinePreferenceKind
       type: string
       description: Kind of virtualMachinePreference object

--- a/templates-pipelines/windows-customize/manifests/windows-customize.yaml
+++ b/templates-pipelines/windows-customize/manifests/windows-customize.yaml
@@ -36,7 +36,7 @@ spec:
     - name: preferenceName
       type: string
       description: Name of VirtualMachineClusterPreference object
-      default: windows.11
+      default: windows.11.virtio
     - name: virtualMachinePreferenceKind
       type: string
       description: Kind of virtualMachinePreference object

--- a/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -29,7 +29,7 @@ spec:
     - name: baseDvName
       value: win2k22-customized
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: customizeConfigMapName
       value: windows-sqlserver
   pipelineRef:
@@ -57,7 +57,7 @@ spec:
     - name: baseDvName
       value: win10-customized
     - name: preferenceName
-      value: windows.10
+      value: windows.10.virtio
   pipelineRef:
     resolver: hub
     params:

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -39,7 +39,7 @@ spec:
     - name: preferenceName
       type: string
       description: Name of VirtualMachineClusterPreference object
-      default: windows.11
+      default: windows.11.virtio
     - name: virtualMachinePreferenceKind
       type: string
       description: Kind of virtualMachinePreference object

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -75,7 +75,7 @@ spec:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
     - name: preferenceName
-      value: windows.2k22
+      value: windows.2k22.virtio
     - name: autounattendConfigMapName
       value: windows2k22-autounattend
     - name: baseDvName


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: change all preferences to use virtio in pipelines

Pipelines are installing virtio drivers and VMs should use the preferences with virtio bus
This PR is follow up of https://github.com/kubevirt/kubevirt-tekton-tasks/pull/409

**Release note**:
```
chore: change all preferences to use virtio in pipelines
```
