### PR TITLE
fix: replace template fedora-server-tiny with fedora-server-medium

### DIFF
--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -66,7 +66,7 @@ func BuildTestSuite() {
 func getCommonTemplatesVersion(templateList *v1.TemplateList) string {
 	var commonTemplatesVersion []int
 	found := false
-	requiredTemplate := "fedora-server-tiny"
+	requiredTemplate := "fedora-server-medium"
 
 	for _, template := range templateList.Items {
 		if strings.HasPrefix(template.Name, requiredTemplate) {


### PR DESCRIPTION
**What this PR does / why we need it**:
the e2e test expects fedora-server-tiny template. This template was removed (https://github.com/kubevirt/common-templates/pull/579). This commit replaces it with fedora-server-medium

**Release note**:
```
NONE
```
