### PR TITLE
chore: add mention about default SA in pipeline readme

### DIFF
--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -36,6 +36,11 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 
 The pipeline uses a ConfigMap containing an `unattend.xml` file for automated customization of Windows. Example ConfigMaps are deployed within the Pipeline. In case you would like to use a different ConfigMap, specify a different URL in the `unattendXMLConfigMapsURL` parameter and adjust `customizeConfigMapName` parameter with correct the `ConfigMap` name. Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-customize/configmaps).
 
+> [!NOTE]
+> By default, the Pipeline requires the ServiceAccount `pipeline` to exist. Tekton does not create this ServiceAccount 
+> in namespaces which name starts with `openshift` or `kube`. In case you would like to run this Pipeline in a namespace which 
+> starts with `openshift` or `kube`, you have to create the `pipeline` ServiceAccount manually or specify a different ServiceAccount in the PipelineRun.
+
 Pipeline runs with resolvers:
 ```yaml
 oc create -f - <<EOF

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -73,6 +73,11 @@ Pipeline uses ConfigMaps with `autounattend.xml` file for automated installation
 > Microsoft end user license agreement(s) for each deployment or installation for the Microsoft product(s). In case you 
 > set it to false, the Pipeline will exit in first task.
 
+> [!NOTE]
+> By default, the Pipeline requires the ServiceAccount `pipeline` to exist. Tekton does not create this ServiceAccount 
+> in namespaces which name starts with `openshift` or `kube`. In case you would like to run this Pipeline in a namespace which 
+> starts with `openshift` or `kube`, you have to create the `pipeline` ServiceAccount manually or specify a different ServiceAccount in the PipelineRun.
+
 Pipeline runs with resolvers:
 ```yaml
 export WIN_IMAGE_DOWNLOAD_URL=$(./getisourl.py) # see paragraph Obtaining a download URL in an automated way

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -36,6 +36,11 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 
 The pipeline uses a ConfigMap containing an `unattend.xml` file for automated customization of Windows. Example ConfigMaps are deployed within the Pipeline. In case you would like to use a different ConfigMap, specify a different URL in the `unattendXMLConfigMapsURL` parameter and adjust `customizeConfigMapName` parameter with correct the `ConfigMap` name. Examples of ConfigMaps can be found [here](https://github.com/kubevirt/kubevirt-tekton-tasks/tree/main/release/pipelines/windows-customize/configmaps).
 
+> [!NOTE]
+> By default, the Pipeline requires the ServiceAccount `pipeline` to exist. Tekton does not create this ServiceAccount 
+> in namespaces which name starts with `openshift` or `kube`. In case you would like to run this Pipeline in a namespace which 
+> starts with `openshift` or `kube`, you have to create the `pipeline` ServiceAccount manually or specify a different ServiceAccount in the PipelineRun.
+
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}
 ```yaml

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -73,6 +73,11 @@ Pipeline uses ConfigMaps with `autounattend.xml` file for automated installation
 > Microsoft end user license agreement(s) for each deployment or installation for the Microsoft product(s). In case you 
 > set it to false, the Pipeline will exit in first task.
 
+> [!NOTE]
+> By default, the Pipeline requires the ServiceAccount `pipeline` to exist. Tekton does not create this ServiceAccount 
+> in namespaces which name starts with `openshift` or `kube`. In case you would like to run this Pipeline in a namespace which 
+> starts with `openshift` or `kube`, you have to create the `pipeline` ServiceAccount manually or specify a different ServiceAccount in the PipelineRun.
+
 Pipeline runs with resolvers:
 {% for item in pipeline_runs_yaml %}
 ```yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add mention about default SA in pipeline readme

by default tekton does not create default SA pipeline in namespaces which start with name openshift or kube. In case user tries to run the pipeline in that namespace, the pipeline will fail. To fix this user has to create the SA manually, or reference different SA in PipelineRun.

**Release note**:
```
NONE
```
