### PR TITLE
chore: pipelines create DataSource

### DIFF
--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -21,16 +21,17 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ## Pipeline Description
 
 ```
-  import-unattend-configmaps --- copy-vm-root-disk --- create-vm --- wait-for-vmi-status --- cleanup-vm --- delete-imported-configmaps
+  import-unattend-configmaps --- copy-vm-root-disk --- create-vm --- wait-for-vmi-status --- create-datasource-root-disk --- cleanup-vm --- delete-imported-configmaps
 ```
 1. `import-unattend-configmaps` imports ConfigMap with `unattend.xml` needed for automated customization of Windows.
 2. `copy-vm-root-disk` Task copies PVC defined in `sourceDiskImageName` and `sourceDiskImageNamespace` parameters.
 3. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`). The VirtualMachine has to be created in the same namespace as the source DataVolume.
 4. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
-5. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
-6. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
-7. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
-8. `delete-imported-configmaps` deletes imported ConfigMaps.
+5. `create-datasource-root-disk` Task creates a DataSource object, which is used by UI for discovering bootable volumes and links PVC created in `copy-vm-root-disk` step.
+6. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
+7. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
+8. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
+9. `delete-imported-configmaps` deletes imported ConfigMaps.
 
 ## How to run
 
@@ -127,4 +128,4 @@ EOF
 
 ## Cancelling/Deleting PipelineRuns
 
-When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.
+When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataSource/DataVolume/PVC.

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -189,6 +189,44 @@ spec:
             value: wait-for-vmi-status
           - name: version
             value: v0.21.0
+    - name: create-datasource-root-disk
+      runAfter:
+        - wait-for-vmi-status
+      taskRef:
+        resolver: hub
+        params:
+          - name: catalog
+            value: kubevirt-tekton-tasks
+          - name: type
+            value: artifact
+          - name: kind
+            value: task
+          - name: name
+            value: modify-data-object
+          - name: version
+            value: v0.21.0
+      params:
+        - name: manifest
+          value: |-
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataSource
+            metadata:
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(tasks.copy-vm-root-disk.results.name)
+              namespace: $(tasks.copy-vm-root-disk.results.namespace)
+            spec:
+              source:
+                pvc:
+                  name: $(tasks.copy-vm-root-disk.results.name)
+                  namespace: $(tasks.copy-vm-root-disk.results.namespace)
+        - name: waitForSuccess
+          value: false
+        - name: allowReplace
+          value: true
   finally:
     - name: cleanup-vm
       params:

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -13,7 +13,7 @@ This helps with automated installation of Windows in EFI boot mode. By default W
 > inside ISO file, the `modify-windows-iso-file` task will exit and whole Pipeline will fail. In case your ISO file has 
 > different file structure, update `modify-windows-iso-file` task accordingly.
 
-After the ISO is modified it creates a new VirtualMachine which boots from the modified Windows installation image (ISO file). The installation of Windows is automatically executed and controlled by a Windows answer file. Then the Pipeline will wait for the installation to complete and will delete the created VirtualMachine while keeping the resulting DataVolume with the installed operating system. The Pipeline can be customized to support different installation requirements.
+After the ISO is modified it creates a new VirtualMachine which boots from the modified Windows installation image (ISO file). The installation of Windows is automatically executed and controlled by a Windows answer file. Then the Pipeline will wait for the installation to complete and will delete the created VirtualMachine while keeping the resulting DataSource/DataVolume with the installed operating system. The Pipeline can be customized to support different installation requirements.
 
 ## Prerequisites
 
@@ -50,9 +50,9 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 ## Pipeline Description
 
 ```
-  import-autounattend-configmaps --- import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- cleanup-vm --- delete-imported-configmaps
+  import-autounattend-configmaps --- import-win-iso --- modify-windows-iso-file --- create-vm --- wait-for-vmi-status --- create-datasource-root-disk --- cleanup-vm --- delete-imported-configmaps
                                                      |
-                              create-vm-root-disk --- 
+                              create-vm-root-disk ---
 ```
 1. `import-autounattend-configmaps` imports ConfigMap with `autounattend.xml` needed for automated installation of Windows.
 2. `create-vm-root-disk` creates empty DataVolume which is used for Windows installation.
@@ -60,9 +60,10 @@ After the ISO is modified it creates a new VirtualMachine which boots from the m
 4. `modify-windows-iso-file` extracts imported ISO file, replaces prompt bootloader (which is used as a default one when EFI is used) with no-prompt bootloader, pack the updated files back to new ISO, convert the ISO and replaces original ISO with updated one.Replacement of bootloader is needed to be able to automate installation of Windows versions which require EFI.
 5. `create-vm` Task creates a VirtualMachine. A DataVolume with the Windows source ISO will be attached as CD-ROM and a second empty DataVolume will be used as installation destination. A third DataVolume with the virtio-win ISO will also be attached (Pipeline parameter `virtioContainerDiskName`). The VirtualMachine has to be created in the same namespace as the DataVolume with the ISO file. In case you would like to run the VirtualMachine in a different namespace, both Datavolumes have to be copied to the same namespace as the VirtualMachine.
 6. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
-7. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
-8. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
-9. `delete-imported-configmaps` deletes imported ConfigMaps.
+7. `create-datasource-root-disk` Task creates a DataSource object, which is used by UI for discovering bootable volumes and links PVC created in `create-vm-root-disk` step.
+8. `cleanup-vm` deletes the installer VirtualMachine and all of its DataVolumes.
+9. The output artifact will be the `baseDvName`/`baseDvNamespace` DataVolume with the basic Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used.
+10. `delete-imported-configmaps` deletes imported ConfigMaps.
 
 ## How to run
 
@@ -202,7 +203,7 @@ EOF
 
 ## Cancelling/Deleting PipelineRuns
 
-When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.
+When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataSource/DataVolume/PVC.
 
 windows-efi-installer Pipeline generates for each PipelineRun new source DataVolume which contains imported ISO file. This DataVolume has generated name and is deleted after Pipeline succeeds. However, the created PVC will stay in cluster, but it will have terminating state. It will wait, until pipelinRun is deleted. This behaviour is caused by a fact, that PVC is mounted into modify-windows-iso TaskRun pod and PVC can be deleted only when the pod does not 
 exist.

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -281,6 +281,44 @@ spec:
           - name: version
             value: v0.21.0
       timeout: 2h0m0s
+    - name: create-datasource-root-disk
+      runAfter:
+        - wait-for-vmi-status
+      taskRef:
+        resolver: hub
+        params:
+          - name: catalog
+            value: kubevirt-tekton-tasks
+          - name: type
+            value: artifact
+          - name: kind
+            value: task
+          - name: name
+            value: modify-data-object
+          - name: version
+            value: v0.21.0
+      params:
+        - name: manifest
+          value: |-
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataSource
+            metadata:
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(tasks.create-vm-root-disk.results.name)
+              namespace: $(tasks.create-vm-root-disk.results.namespace)
+            spec:
+              source:
+                pvc:
+                  name: $(tasks.create-vm-root-disk.results.name)
+                  namespace: $(tasks.create-vm-root-disk.results.namespace)
+        - name: waitForSuccess
+          value: false
+        - name: allowReplace
+          value: true
   finally:
     - name: cleanup-vm
       params:

--- a/templates-pipelines/windows-customize/README.md
+++ b/templates-pipelines/windows-customize/README.md
@@ -21,16 +21,17 @@ The provided reference ConfigMap (`windows-sqlserver`) boots Windows 10, 11 or W
 ## Pipeline Description
 
 ```
-  import-unattend-configmaps --- copy-vm-root-disk --- create-vm --- wait-for-vmi-status --- cleanup-vm --- delete-imported-configmaps
+  import-unattend-configmaps --- copy-vm-root-disk --- create-vm --- wait-for-vmi-status --- create-datasource-root-disk --- cleanup-vm --- delete-imported-configmaps
 ```
 1. `import-unattend-configmaps` imports ConfigMap with `unattend.xml` needed for automated customization of Windows.
 2. `copy-vm-root-disk` Task copies PVC defined in `sourceDiskImageName` and `sourceDiskImageNamespace` parameters.
 3. `create-vm` Task creates a VirtualMachine called `windows-customize-*` from the base DataVolume and with the customize ConfigMap attached as a CD-ROM (Pipeline parameter `customizeConfigMapName`). The VirtualMachine has to be created in the same namespace as the source DataVolume.
 4. `wait-for-vmi-status` Task waits until the VirtualMachine shuts down.
-5. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
-6. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
-7. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
-8. `delete-imported-configmaps` deletes imported ConfigMaps.
+5. `create-datasource-root-disk` Task creates a DataSource object, which is used by UI for discovering bootable volumes and links PVC created in `copy-vm-root-disk` step.
+6. `cleanup-vm` deletes the installer VirtualMachine (also in case of failure of the previous Tasks).
+7. The output artifact will be the `win*-customized` DataVolume with the customized Windows installation. It will boot into the Windows OOBE and needs to be setup further before it can be used (depends on the applied customizations).
+8. The `windows11-unattend` ConfigMap can be used to boot the VirtualMachine into the Desktop (depends on the applied customizations).
+9. `delete-imported-configmaps` deletes imported ConfigMaps.
 
 ## How to run
 
@@ -51,4 +52,4 @@ oc create -f - <<EOF
 
 ## Cancelling/Deleting PipelineRuns
 
-When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataVolume/PVC.
+When running the example Pipelines, they create temporary objects (DataVolumes, VirtualMachines, etc.). Each Pipeline has its own clean up system which should keep the cluster clean from leftovers. In case user hard deletes or cancels running PipelineRun, the PipelineRun will not clean temporary objects and objects will stay in the cluster and then they have to be deleted manually. To prevent this behaviour, cancel the [PipelineRun gracefully](https://tekton.dev/docs/pipelines/pipelineruns/#gracefully-cancelling-a-pipelinerun). It triggers special Tasks, which remove temporary objects and keep only result DataSource/DataVolume/PVC.

--- a/templates-pipelines/windows-customize/manifests/windows-customize.yaml
+++ b/templates-pipelines/windows-customize/manifests/windows-customize.yaml
@@ -204,6 +204,49 @@ spec:
         kind: Task
         name: wait-for-vmi-status
 {% endif %}
+    - name: create-datasource-root-disk
+      runAfter:
+        - wait-for-vmi-status
+      taskRef:
+{% if use_resolver_in_manifests %}
+        resolver: hub
+        params:
+          - name: catalog
+            value: {{ catalog }}
+          - name: type
+            value: {{ catalog_type }}
+          - name: kind
+            value: task
+          - name: name
+            value: modify-data-object
+          - name: version
+            value: {{ catalog_version }}
+{% else %}
+        kind: Task
+        name: modify-data-object
+{% endif %}
+      params:
+        - name: manifest
+          value: |-
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataSource
+            metadata:
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(tasks.copy-vm-root-disk.results.name)
+              namespace: $(tasks.copy-vm-root-disk.results.namespace)
+            spec:
+              source:
+                pvc:
+                  name: $(tasks.copy-vm-root-disk.results.name)
+                  namespace: $(tasks.copy-vm-root-disk.results.namespace)
+        - name: waitForSuccess
+          value: false
+        - name: allowReplace
+          value: true
   finally:
     - name: cleanup-vm
       params:

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -306,6 +306,49 @@ spec:
         name: wait-for-vmi-status
 {% endif %}
       timeout: 2h0m0s
+    - name: create-datasource-root-disk
+      runAfter:
+        - wait-for-vmi-status
+      taskRef:
+{% if use_resolver_in_manifests %}
+        resolver: hub
+        params:
+          - name: catalog
+            value: {{ catalog }}
+          - name: type
+            value: {{ catalog_type }}
+          - name: kind
+            value: task
+          - name: name
+            value: modify-data-object
+          - name: version
+            value: {{ catalog_version }}
+{% else %}
+        kind: Task
+        name: modify-data-object
+{% endif %}
+      params:
+        - name: manifest
+          value: |-
+            apiVersion: cdi.kubevirt.io/v1beta1
+            kind: DataSource
+            metadata:
+              labels:
+                "instancetype.kubevirt.io/default-instancetype-kind": $(params.instanceTypeKind)
+                "instancetype.kubevirt.io/default-instancetype": $(params.instanceTypeName)
+                "instancetype.kubevirt.io/default-preference-kind": $(params.virtualMachinePreferenceKind)
+                "instancetype.kubevirt.io/default-preference": $(params.preferenceName)
+              name: $(tasks.create-vm-root-disk.results.name)
+              namespace: $(tasks.create-vm-root-disk.results.namespace)
+            spec:
+              source:
+                pvc:
+                  name: $(tasks.create-vm-root-disk.results.name)
+                  namespace: $(tasks.create-vm-root-disk.results.namespace)
+        - name: waitForSuccess
+          value: false
+        - name: allowReplace
+          value: true
   finally:
     - name: cleanup-vm
       params:


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: pipelines create DataSource

Pipelines now creates DataSource object, which is used by UI and is pointing to result DV/PVC. The DataSource will not be deleted when the PipelineRun is finished.

**Release note**:
```
chore: pipelines create DataSource

```
