### PR TITLE
chore: change the IDs in securityContext of PipelineRuns/TaskRuns

### DIFF
--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -110,9 +110,8 @@ spec:
     -   pipelineTaskName: modify-windows-iso-file
         podTemplate:
             securityContext:
-                fsGroup: 1001
-                runAsGroup: 1001
-                runAsUser: 1001
+                fsGroup: 107
+                runAsUser: 107
 EOF
 ```
 ```yaml
@@ -150,9 +149,8 @@ spec:
     -   pipelineTaskName: modify-windows-iso-file
         podTemplate:
             securityContext:
-                fsGroup: 1001
-                runAsGroup: 1001
-                runAsUser: 1001
+                fsGroup: 107
+                runAsUser: 107
     timeout: 1h0m0s
 EOF
 ```
@@ -193,9 +191,8 @@ spec:
     -   pipelineTaskName: modify-windows-iso-file
         podTemplate:
             securityContext:
-                fsGroup: 1001
-                runAsGroup: 1001
-                runAsUser: 1001
+                fsGroup: 107
+                runAsUser: 107
     timeout: 1h0m0s
 EOF
 ```
@@ -222,4 +219,16 @@ Run it as follows to initialize a WIN_URL variable.
 ```bash
 # Real URL can look differently
 WIN_IMAGE_DOWNLOAD_URL=$(./getisourl.py)
+```
+
+### Common Errors
+- The `modify-windows-iso-file` task can end with error `guestfish: access: /tmp/target-pvc/disk.img: Permissions denied`. This error means, the guestfish cannot access the Windows ISO file due to wrong permissions set on the file. This issue can be fixed by adding `taskRunSpecs` to the spec of the PipelineRun:
+```
+spec:
+  taskRunSpecs:
+    - pipelineTaskName: modify-windows-iso-file
+      podTemplate:
+        securityContext:
+          fsGroup: 107
+          runAsUser: 107
 ```

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -26,9 +26,8 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001   
+          runAsUser: 107
+          fsGroup: 107   
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -63,9 +62,8 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001     
+          runAsUser: 107
+          fsGroup: 107     
   timeout: 1h0m0s
 ---
 apiVersion: tekton.dev/v1
@@ -103,7 +101,6 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001     
+          runAsUser: 107
+          fsGroup: 107     
   timeout: 1h0m0s

--- a/release/tasks/disk-virt-customize/README.md
+++ b/release/tasks/disk-virt-customize/README.md
@@ -23,6 +23,10 @@ spec:
         value: example-pvc
     -   name: customizeCommands
         value: install make,ansible
+    podTemplate:
+        securityContext:
+            fsGroup: 107
+            runAsUser: 107
     taskRef:
         params:
         -   name: catalog
@@ -43,6 +47,15 @@ spec:
 - The input PVC disk should not be accessed by a running VM or other tools like virt-customize concurrently.
 The task will fail with a generic `...guestfs_launch failed...` message.
 Verbose parameter can be set to true for more information.
+
+- The task can end with error `Permissions denied`. This error means, the disk-virt-customize cannot access the VM image due to wrong permissions set on the file. This issue can be fixed by adding `podTemplate` to the spec of the TaskRun:
+```
+spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107
+```
 
 ### OS support
 

--- a/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
@@ -23,3 +23,7 @@ spec:
     - name: customizeCommands
       value: |-
         install make,ansible
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
+++ b/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-workspace.yaml
@@ -27,3 +27,7 @@ spec:
     - name: data
       secret:
         name: disk-virt-customize-taskrun-workspace
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/release/tasks/disk-virt-sysprep/README.md
+++ b/release/tasks/disk-virt-sysprep/README.md
@@ -23,6 +23,10 @@ spec:
         value: example-pvc
     -   name: sysprepCommands
         value: install make,ansible
+    podTemplate:
+        securityContext:
+            fsGroup: 107
+            runAsUser: 107
     taskRef:
         params:
         -   name: catalog
@@ -43,6 +47,15 @@ spec:
 - The input PVC disk should not be accessed by a running VM or other tools like virt-sysprep task concurrently.
 The task will fail with a generic `...guestfs_launch failed...` message.
 A verbose parameter can be set to true for more information.
+
+- The task can end with error `Permissions denied`. This error means, the disk-virt-sysprep cannot access the VM image due to wrong permissions set on the file. This issue can be fixed by adding `podTemplate` to the spec of the TaskRun:
+```
+spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107
+```
 
 ### OS support
 

--- a/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
@@ -23,3 +23,7 @@ spec:
     - name: sysprepCommands
       value: |-
         install make,ansible
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-workspace.yaml
@@ -27,3 +27,7 @@ spec:
     - name: data
       secret:
         name: disk-virt-sysprep-taskrun-workspace
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -113,3 +113,15 @@ Run it as follows to initialize a WIN_URL variable.
 # Real URL can look differently
 WIN_IMAGE_DOWNLOAD_URL=$(./getisourl.py)
 ```
+
+### Common Errors
+- The `modify-windows-iso-file` task can end with error `guestfish: access: /tmp/target-pvc/disk.img: Permissions denied`. This error means, the guestfish cannot access the Windows ISO file due to wrong permissions set on the file. This issue can be fixed by adding `taskRunSpecs` to the spec of the PipelineRun:
+```
+spec:
+  taskRunSpecs:
+    - pipelineTaskName: modify-windows-iso-file
+      podTemplate:
+        securityContext:
+          fsGroup: 107
+          runAsUser: 107
+```

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -26,9 +26,8 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001   
+          runAsUser: 107
+          fsGroup: 107   
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -63,9 +62,8 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001     
+          runAsUser: 107
+          fsGroup: 107     
   timeout: 1h0m0s
 ---
 apiVersion: tekton.dev/v1
@@ -103,7 +101,6 @@ spec:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
         securityContext:
-          runAsUser: 1001
-          runAsGroup: 1001
-          fsGroup: 1001     
+          runAsUser: 107
+          fsGroup: 107     
   timeout: 1h0m0s

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun-workspace.yaml
@@ -27,3 +27,7 @@ spec:
     - name: data
       secret:
         name: {{ item.name }}
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
+++ b/templates/disk-virt-customize/examples/disk-virt-customize-taskrun.yaml
@@ -23,3 +23,7 @@ spec:
     - name: customizeCommands
       value: |-
         install make,ansible
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/templates/disk-virt-customize/readmes/README.md
+++ b/templates/disk-virt-customize/readmes/README.md
@@ -20,6 +20,15 @@ Task run using resolver:
 The task will fail with a generic `...guestfs_launch failed...` message.
 Verbose parameter can be set to true for more information.
 
+- The task can end with error `Permissions denied`. This error means, the disk-virt-customize cannot access the VM image due to wrong permissions set on the file. This issue can be fixed by adding `podTemplate` to the spec of the TaskRun:
+```
+spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107
+```
+
 ### OS support
 
 - Linux: full; all the customize commands work

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun-workspace.yaml
@@ -27,3 +27,7 @@ spec:
     - name: data
       secret:
         name: {{ item.name }}
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
+++ b/templates/disk-virt-sysprep/examples/disk-virt-sysprep-taskrun.yaml
@@ -23,3 +23,7 @@ spec:
     - name: sysprepCommands
       value: |-
         install make,ansible
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107

--- a/templates/disk-virt-sysprep/readmes/README.md
+++ b/templates/disk-virt-sysprep/readmes/README.md
@@ -20,6 +20,15 @@ Task run using resolver:
 The task will fail with a generic `...guestfs_launch failed...` message.
 A verbose parameter can be set to true for more information.
 
+- The task can end with error `Permissions denied`. This error means, the disk-virt-sysprep cannot access the VM image due to wrong permissions set on the file. This issue can be fixed by adding `podTemplate` to the spec of the TaskRun:
+```
+spec:
+  podTemplate:
+    securityContext:
+      fsGroup: 107
+      runAsUser: 107
+```
+
 ### OS support
 
 - Linux: full; all the sysprep commands work


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: change the IDs in securityContext of PipelineRuns/TaskRuns

The IDs defined in securityContext of example PipelineRuns are not accurate. The disk has preset IDs 107 (qemu user). It makes sense to use the same IDs for PipelineRun / TaskRun.
Added mention and solution about issue with permission denied in disk-virt tasks readmes.

**Release note**:
```
NONE
```
