### PR TITLE
fix: missing acceptEula param in win10 PipelineRun

### DIFF
--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -125,6 +125,8 @@ spec:
     params:
     -   name: winImageDownloadURL
         value: ${WIN_IMAGE_DOWNLOAD_URL}
+    -   name: acceptEula
+        value: false
     -   name: preferenceName
         value: windows.10.virtio
     -   name: autounattendConfigMapName

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -37,6 +37,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: acceptEula
+      value: false
     - name: preferenceName
       value: windows.10.virtio
     - name: autounattendConfigMapName

--- a/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/templates-pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -37,6 +37,8 @@ spec:
   params:
     - name: winImageDownloadURL
       value: ${WIN_IMAGE_DOWNLOAD_URL}
+    - name: acceptEula
+      value: false
     - name: preferenceName
       value: windows.10.virtio
     - name: autounattendConfigMapName


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: missing acceptEula param in win10 PipelineRun

**Release note**:
```
fix: missing acceptEula param in win10 PipelineRun

```
