### PR TITLE
chore: add useBiosMode parameter to efi-pipeline

### DIFF
--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -235,3 +235,6 @@ spec:
           fsGroup: 107
           runAsUser: 107
 ```
+- Windows preferences in older KubeVirt versions might still use Bios mode. In that case, set the `useBiosMode` parameter 
+to `true`. This will skip the `modify-windows-iso-file` task. In case the the Windows preference uses Bios and the 
+`useBiosMode` parameter is not set to true, the Windows VM will not work.

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -67,6 +67,10 @@ spec:
       description: Name of Windows ISO datavolume
       name: isoDVName
       type: string
+    - default: false
+      description: In older preferences, Windows 10 preference might still use Bios. In that case the step modify-windows-iso-file should not run. If the preference uses Bios, set this parameter to true.
+      name: useBiosMode
+      type: string
   tasks:
     - name: import-autounattend-configmaps
       params:
@@ -131,6 +135,10 @@ spec:
           - name: version
             value: v0.22.0
     - name: modify-windows-iso-file
+      when:
+        - input: "$(params.useBiosMode)"
+          operator: in
+          values: ["false"]
       params:
         - name: pvcName
           value: $(tasks.import-win-iso.results.name)

--- a/templates-pipelines/windows-efi-installer/README.md
+++ b/templates-pipelines/windows-efi-installer/README.md
@@ -126,3 +126,6 @@ spec:
           fsGroup: 107
           runAsUser: 107
 ```
+- Windows preferences in older KubeVirt versions might still use Bios mode. In that case, set the `useBiosMode` parameter 
+to `true`. This will skip the `modify-windows-iso-file` task. In case the the Windows preference uses Bios and the 
+`useBiosMode` parameter is not set to true, the Windows VM will not work.

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -67,6 +67,10 @@ spec:
       description: Name of Windows ISO datavolume
       name: isoDVName
       type: string
+    - default: false
+      description: In older preferences, Windows 10 preference might still use Bios. In that case the step modify-windows-iso-file should not run. If the preference uses Bios, set this parameter to true.
+      name: useBiosMode
+      type: string
   tasks:
     - name: import-autounattend-configmaps
       params:
@@ -136,6 +140,10 @@ spec:
         name: modify-data-object
 {% endif %}
     - name: modify-windows-iso-file
+      when:
+        - input: "$(params.useBiosMode)"
+          operator: in
+          values: ["false"]
       params:
         - name: pvcName
           value: $(tasks.import-win-iso.results.name)


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add useBiosMode parameter to efi-pipeline

Windows preferences in older KubeVirt versions might still use Bios mode. In that case, set the `useBiosMode` parameter to `true`. This will skip the `modify-windows-iso-file` task. In case the the Windows preference uses Bios and the `useBiosMode` parameter is not set to true, the Windows VM will not work.

**Release note**:
```
chore: add useBiosMode parameter to efi-pipeline
```
