### PR TITLE
fix: use fedora-medium template in e2e test

### DIFF
--- a/test/create_vm_from_template_test.go
+++ b/test/create_vm_from_template_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Create VM from template", func() {
 				ExpectedLogs: ExpectedSuccessfulVMCreation,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
-				TemplateName:      SpacesSmall + "fedora-server-tiny",
+				TemplateName:      SpacesSmall + "fedora-server-medium",
 				TemplateNamespace: SpacesSmall + "openshift" + SpacesSmall,
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-common-template")),


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: use fedora-medium template in e2e test

The fedora-server-small is no longer shipped in Common Templates releases
**Release note**:
```
fix: use fedora-medium template in e2e test
```
