### PR TITLE
chore: add owner references to copy-template task

### DIFF
--- a/modules/copy-template/pkg/utils/parse/clioptions.go
+++ b/modules/copy-template/pkg/utils/parse/clioptions.go
@@ -22,6 +22,7 @@ type CLIOptions struct {
 	TargetTemplateName      string            `arg:"--target-template-name,env:TARGET_TEMPLATE_NAME" placeholder:"NAME" help:"Name of a target template"`
 	TargetTemplateNamespace string            `arg:"--target-template-namespace,env:TARGET_TEMPLATE_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace of a target template"`
 	AllowReplace            string            `arg:"--allow-replace,env:ALLOW_REPLACE" placeholder:"false" help:"Allow replacing already existing template (same combination name/namespace). Allowed values true/false"`
+	SetOwnerReference       string            `arg:"--set-owner-reference,env:SET_OWNER_REFERENCE" placeholder:"false" help:"Set owner reference to the new object created by the task run pod. Allowed values true/false"`
 	Output                  output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug                   bool              `arg:"--debug" help:"Sets DEBUG log level"`
 }
@@ -51,6 +52,10 @@ func (c *CLIOptions) GetTargetTemplateName() string {
 
 func (c *CLIOptions) GetAllowReplaceValue() bool {
 	return c.AllowReplace == "true"
+}
+
+func (c *CLIOptions) GetSetOwnerReferenceValue() bool {
+	return c.SetOwnerReference == "true"
 }
 
 func (c *CLIOptions) Init() error {

--- a/modules/shared/pkg/ownerreference/ownerreference.go
+++ b/modules/shared/pkg/ownerreference/ownerreference.go
@@ -1,0 +1,62 @@
+package ownerreference
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	podNameEnv      = "POD_NAME"
+	podNamespaceEnv = "POD_NAMESPACE"
+)
+
+func getTaskRunPod(k8sClient *k8sv1.CoreV1Client) (*corev1.Pod, error) {
+	podName, isSet := os.LookupEnv(podNameEnv)
+	if !isSet {
+		return nil, fmt.Errorf("pod name env variable is not set")
+	}
+
+	podNamespace, isSet := os.LookupEnv(podNamespaceEnv)
+	if !isSet {
+		return nil, fmt.Errorf("pod namespace env variable is not set")
+	}
+
+	pod := &corev1.Pod{}
+	pod, err := k8sClient.Pods(podNamespace).Get(context.Background(), podName, metav1.GetOptions{})
+	return pod, err
+}
+
+func SetPodOwnerReference(k8sClient *k8sv1.CoreV1Client, object metav1.Object) error {
+	pod, err := getTaskRunPod(k8sClient)
+	if err != nil {
+		return err
+	}
+
+	if object.GetNamespace() != pod.GetNamespace() {
+		return fmt.Errorf("can't create owner reference for objects in different namespaces")
+	}
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+
+	gvks, _, err := scheme.ObjectKinds(pod)
+	if err != nil {
+		return fmt.Errorf("could not get GroupVersionKind for object: %w", err)
+	}
+	ref := metav1.OwnerReference{
+		APIVersion: gvks[0].GroupVersion().String(),
+		Kind:       gvks[0].Kind,
+		UID:        pod.GetUID(),
+		Name:       pod.GetName(),
+	}
+
+	object.SetOwnerReferences([]metav1.OwnerReference{ref})
+	return nil
+
+}

--- a/release/tasks/copy-template/README.md
+++ b/release/tasks/copy-template/README.md
@@ -12,6 +12,7 @@ A bundle of predefined templates to use can be found in [Common Templates](https
 - **targetTemplateName**: Name of an target OpenShift template.
 - **targetTemplateNamespace**: Namespace of an target OpenShift template to create in. (defaults to active namespace)
 - **allowReplace**: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
+- **setOwnerReference**: Set owner reference to the new object created by the task run pod. Allowed values true/false
 
 ### Results
 

--- a/release/tasks/copy-template/copy-template.yaml
+++ b/release/tasks/copy-template/copy-template.yaml
@@ -44,6 +44,10 @@ spec:
       description: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a template that was created.
@@ -67,3 +71,13 @@ spec:
           value: $(params.targetTemplateNamespace)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/templates/copy-template/manifests/copy-template.yaml
+++ b/templates/copy-template/manifests/copy-template.yaml
@@ -44,6 +44,10 @@ spec:
       description: Allow replacing already existing template (same combination name/namespace). Allowed values true/false
       type: string
       default: "false"
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a template that was created.
@@ -67,3 +71,13 @@ spec:
           value: $(params.targetTemplateNamespace)
         - name: ALLOW_REPLACE
           value: $(params.allowReplace)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/test/constants/copy-template.go
+++ b/test/constants/copy-template.go
@@ -10,4 +10,5 @@ const (
 	TargetTemplateNameOptionName      = "targetTemplateName"
 	TargetTemplateNamespaceOptionName = "targetTemplateNamespace"
 	AllowReplaceOptionName            = "allowReplace"
+	SetOwnerReference                 = "setOwnerReference"
 )

--- a/test/copy_template_test.go
+++ b/test/copy_template_test.go
@@ -78,6 +78,14 @@ var _ = Describe("Copy template task", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(newTemplate).ToNot(BeNil(), "new template should exists")
 
+			if config.TaskData.SetOwnerReference == "true" {
+				Expect(newTemplate.OwnerReferences).To(HaveLen(1), "template should has owner reference")
+				Expect(newTemplate.OwnerReferences[0].Kind).To(Equal("Pod"), "OwnerReference should have Kind Pod")
+				Expect(newTemplate.OwnerReferences[0].Name).To(HavePrefix("e2e-tests-taskrun-copy-template"), "OwnerReference should be binded to correct Pod")
+			} else {
+				Expect(newTemplate.OwnerReferences).To(BeEmpty(), "template OwnerReference should be empty")
+			}
+
 			f.ManageTemplates(newTemplate)
 		},
 			Entry("should create template in the same namespace", &testconfigs.CopyTemplateTestConfig{
@@ -86,6 +94,7 @@ var _ = Describe("Copy template task", func() {
 					SourceTemplateName: testtemplate.CirrosTemplateName,
 					TargetTemplateName: NewTemplateName,
 					Template:           testtemplate.NewCirrosServerTinyTemplate().Build(),
+					SetOwnerReference:  "true",
 				},
 			}),
 			Entry("no target template name specified", &testconfigs.CopyTemplateTestConfig{
@@ -93,6 +102,7 @@ var _ = Describe("Copy template task", func() {
 				TaskData: testconfigs.CopyTemplateTaskData{
 					SourceTemplateName: testtemplate.CirrosTemplateName,
 					Template:           testtemplate.NewCirrosServerTinyTemplate().Build(),
+					SetOwnerReference:  "false",
 				},
 			}),
 			Entry("no target namespaces specified", &testconfigs.CopyTemplateTestConfig{
@@ -127,6 +137,7 @@ var _ = Describe("Copy template task", func() {
 					SourceTemplateName: testtemplate.RhelTemplateName,
 					TargetTemplateName: NewTemplateName,
 					Template:           testtemplate.NewRhelDesktopTinyTemplate().Build(),
+					SetOwnerReference:  "true",
 				},
 			}
 			f.TestSetup(config)
@@ -153,6 +164,7 @@ var _ = Describe("Copy template task", func() {
 
 			checkRemovedRecordsTemplate(newTemplate.Labels)
 			checkRemovedRecordsTemplate(newTemplate.Annotations)
+			Expect(newTemplate.OwnerReferences).To(HaveLen(1), "template should has owner reference")
 
 			vm, _, err := zutils.DecodeVM(newTemplate)
 			Expect(err).ToNot(HaveOccurred())
@@ -203,6 +215,7 @@ var _ = Describe("Copy template task", func() {
 					TargetTemplateName: NewTemplateName,
 					AllowReplace:       "true",
 					Template:           testtemplate.NewCirrosServerTinyTemplate().Build(),
+					SetOwnerReference:  "true",
 				},
 			}
 			f.TestSetup(config)
@@ -232,7 +245,9 @@ var _ = Describe("Copy template task", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(newTemplate).ToNot(BeNil(), " template should exists")
 			Expect(newTemplate.Objects).To(HaveLen(1), "template should be updated")
-
+			Expect(newTemplate.OwnerReferences).To(HaveLen(1), "template should has owner reference")
+			Expect(newTemplate.OwnerReferences[0].Kind).To(Equal("Pod"), "OwnerReference should have Kind Pod")
+			Expect(newTemplate.OwnerReferences[0].Name).To(HavePrefix("e2e-tests-taskrun-copy-template"), "OwnerReference should be binded to correct Pod")
 			f.ManageTemplates(newTemplate)
 		})
 	})

--- a/test/testconfigs/copy-template-config.go
+++ b/test/testconfigs/copy-template-config.go
@@ -14,6 +14,7 @@ type CopyTemplateTaskData struct {
 	SourceTemplateName         string
 	TargetTemplateName         string
 	AllowReplace               string
+	SetOwnerReference          string
 	UsePlainTargetTemplateName bool
 }
 
@@ -74,6 +75,12 @@ func (c *CopyTemplateTestConfig) GetTaskRun() *pipev1.TaskRun {
 			Value: pipev1.ParamValue{
 				Type:      pipev1.ParamTypeString,
 				StringVal: c.TaskData.AllowReplace,
+			},
+		}, {
+			Name: SetOwnerReference,
+			Value: pipev1.ParamValue{
+				Type:      pipev1.ParamTypeString,
+				StringVal: c.TaskData.SetOwnerReference,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add owner references to copy-template task

If this parameter is set to true, the task add ownerreference
to newly created template and binds it to the task run pod.
This will help during cleanup of objects.

**Release note**:

```
chore: add owner references to copy-template task
```
