### PR TITLE
chore: add ownerReference param to create-vm tasks

### DIFF
--- a/modules/create-vm/pkg/utils/parse/clioptions.go
+++ b/modules/create-vm/pkg/utils/parse/clioptions.go
@@ -30,6 +30,7 @@ type CLIOptions struct {
 	VirtualMachineNamespace string            `arg:"--vm-namespace,env:VM_NAMESPACE" placeholder:"NAMESPACE" help:"Namespace where to create the VM"`
 	StartVM                 string            `arg:"--start-vm,env:START_VM" help:"Start vm after creation"`
 	RunStrategy             string            `arg:"--run-strategy,env:RUN_STRATEGY" help:"Set run strategy to vm"`
+	SetOwnerReference       string            `arg:"--set-owner-reference,env:SET_OWNER_REFERENCE" placeholder:"false" help:"Set owner reference to the new object created by the task run pod. Allowed values true/false"`
 	Output                  output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug                   bool              `arg:"--debug" help:"Sets DEBUG log level"`
 	Virtctl                 string            `arg:"--virtctl,env:VIRTCTL" placeholder:"VIRTCTL" help:"Specifies the parameters for virtctl create vm command that will be used to create VirtualMachine."`
@@ -45,6 +46,10 @@ func (c *CLIOptions) GetRunStrategy() string {
 
 func (c *CLIOptions) GetVirtctl() string {
 	return c.Virtctl
+}
+
+func (c *CLIOptions) GetSetOwnerReferenceValue() bool {
+	return c.SetOwnerReference == "true"
 }
 
 func (c *CLIOptions) GetTemplateParams() map[string]string {

--- a/release/tasks/create-vm-from-manifest/README.md
+++ b/release/tasks/create-vm-from-manifest/README.md
@@ -9,6 +9,7 @@ This task creates a VirtualMachine from YAML manifest
 - **namespace**: Namespace where to create the VM. (defaults to manifest namespace or active namespace)
 - **startVM**: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
 - **runStrategy**: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
+- **setOwnerReference**: Set owner reference to the new object created by the task run pod. Allowed values true/false
 
 ### Results
 

--- a/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -44,6 +44,10 @@ spec:
       description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a VM that was created.
@@ -65,5 +69,15 @@ spec:
           value: $(params.virtctl)
         - name: START_VM
           value: $(params.startVM)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
         - name: RUN_STRATEGY
           value: $(params.runStrategy)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/release/tasks/create-vm-from-template/README.md
+++ b/release/tasks/create-vm-from-template/README.md
@@ -14,6 +14,7 @@ A bundle of predefined templates to use can be found in [Common Templates](https
 - **vmNamespace**: Namespace where to create the VM. (defaults to active namespace)
 - **startVM**: Set to true or false to start / not start vm after creation. In case of runStrategy is set to Always, startVM flag is ignored.
 - **runStrategy**: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
+- **setOwnerReference**: Set owner reference to the new object created by the task run pod. Allowed values true/false
 
 ### Results
 

--- a/release/tasks/create-vm-from-template/create-vm-from-template.yaml
+++ b/release/tasks/create-vm-from-template/create-vm-from-template.yaml
@@ -48,6 +48,10 @@ spec:
       description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a VM that was created.
@@ -71,5 +75,15 @@ spec:
           value: $(params.vmNamespace)
         - name: START_VM
           value: $(params.startVM)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
         - name: RUN_STRATEGY
           value: $(params.runStrategy)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -69,6 +69,10 @@ spec:
       description: Set runStrategy to VM. If runStrategy is set, vm.spec.running attribute is set to nil.
       default: ""
       type: string
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of a VM that was created.
@@ -102,5 +106,15 @@ spec:
 {% endif %}
         - name: START_VM
           value: $(params.startVM)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
         - name: RUN_STRATEGY
           value: $(params.runStrategy)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/test/testconfigs/vm-test-config.go
+++ b/test/testconfigs/vm-test-config.go
@@ -35,9 +35,10 @@ type CreateVMTaskData struct {
 	// this is set if VM is not nil
 	VMManifest string
 
-	TemplateParams []string
-	VMNamespace    string
-	Virtctl        string
+	SetOwnerReference string
+	TemplateParams    []string
+	VMNamespace       string
+	Virtctl           string
 }
 
 func (c *CreateVMTaskData) GetTemplateParam(key string) string {
@@ -154,6 +155,12 @@ func (c *CreateVMTestConfig) GetTaskRun() *pipev1.TaskRun {
 			Value: pipev1.ParamValue{
 				Type:      pipev1.ParamTypeString,
 				StringVal: c.TaskData.RunStrategy,
+			},
+		}, {
+			Name: SetOwnerReference,
+			Value: pipev1.ParamValue{
+				Type:      pipev1.ParamTypeString,
+				StringVal: c.TaskData.SetOwnerReference,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add ownerReference param to create-vm tasks

This commit adds new param setOwnerReference to create-vm tasks. If set to true, the VM object will have OwnerReference by TaskRun pod.

**Release note**:
```
chore: add ownerReference param to create-vm tasks
```
