### PR TITLE
chore: add ownerReference param to modify-data-object task

### DIFF
--- a/modules/modify-data-object/pkg/utils/parse/clioptions.go
+++ b/modules/modify-data-object/pkg/utils/parse/clioptions.go
@@ -28,6 +28,7 @@ type CLIOptions struct {
 	DeleteObject        string            `arg:"--delete-object,env:DELETE_OBJECT" help:"Delete data object with given name. Parameters name, object-kind have to be defined."`
 	DeleteObjectKind    string            `arg:"--delete-object-kind,env:DELETE_OBJECT_KIND" help:"Kind of the data object to delete. This parameter is used only for Delete operation."`
 	AllowReplace        string            `arg:"--allow-replace,env:ALLOW_REPLACE" placeholder:"false" help:"Allow replacing an already existing data object (same combination name/namespace). Allowed values true/false (can be set by ALLOW_REPLACE env variable)."`
+	SetOwnerReference   string            `arg:"--set-owner-reference,env:SET_OWNER_REFERENCE" placeholder:"false" help:"Set owner reference to the new object created by the task run pod. Allowed values true/false"`
 	Output              output.OutputType `arg:"-o" placeholder:"FORMAT" help:"Output format. One of: yaml|json"`
 	Debug               bool              `arg:"--debug" help:"Sets DEBUG log level"`
 
@@ -55,6 +56,10 @@ func (c *CLIOptions) GetWaitForSuccess() bool {
 
 func (c *CLIOptions) GetAllowReplace() bool {
 	return c.AllowReplace == "true"
+}
+
+func (c *CLIOptions) GetSetOwnerReferenceValue() bool {
+	return c.SetOwnerReference == "true"
 }
 
 func (c *CLIOptions) GetDeleteObject() bool {

--- a/release/tasks/modify-data-object/README.md
+++ b/release/tasks/modify-data-object/README.md
@@ -11,6 +11,7 @@ This task modifies a data object (DataVolumes or DataSources).
 - **deleteObject**: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
 - **deleteObjectKind**: Kind of the data object to delete. This parameter is used only for Delete operation.
 - **deleteObjectName**: Name of the data object to delete. This parameter is used only for Delete operation.
+- **setOwnerReference**: Set owner reference to the new object created by the task run pod. Allowed values true/false
   
 ### Results
 

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -50,6 +50,10 @@ spec:
       description: Name of the data object to delete. This parameter is used only for Delete operation.
       default: ""
       type: string
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of the data object that was created.
@@ -77,3 +81,13 @@ spec:
           value: $(params.deleteObjectKind)
         - name: DELETE_OBJECT_NAME
           value: $(params.deleteObjectName)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -50,6 +50,10 @@ spec:
       description: Name of the data object to delete. This parameter is used only for Delete operation.
       default: ""
       type: string
+    - name: setOwnerReference
+      description: Set owner reference to the new object created by the task run pod. Allowed values true/false
+      type: string
+      default: "false"
   results:
     - name: name
       description: The name of the data object that was created.
@@ -77,3 +81,13 @@ spec:
           value: $(params.deleteObjectKind)
         - name: DELETE_OBJECT_NAME
           value: $(params.deleteObjectName)
+        - name: SET_OWNER_REFERENCE
+          value: $(params.setOwnerReference)
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/test/modify_data_object_test.go
+++ b/test/modify_data_object_test.go
@@ -85,6 +85,18 @@ var _ = Describe("Modify data objects", func() {
 
 			err := dataobject.WaitForSuccessfulDataVolume(f.KubevirtClient, dv.Namespace, dv.Name, config.GetWaitForDataObjectTimeout())
 			Expect(err).ShouldNot(HaveOccurred())
+
+			dv, err = f.CdiClient.DataVolumes(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			if config.TaskData.SetOwnerReference == "true" {
+				Expect(dv.OwnerReferences).To(HaveLen(1), "dv should has owner reference")
+				Expect(dv.OwnerReferences[0].Kind).To(Equal("Pod"), "OwnerReference should have Kind Pod")
+				Expect(dv.OwnerReferences[0].Name).To(HavePrefix("e2e-tests-taskrun-modify-data-object"), "OwnerReference should be binded to correct Pod")
+			} else {
+				Expect(dv.OwnerReferences).To(BeEmpty(), "dv OwnerReference should be empty")
+			}
+
 		},
 			Entry("blank no wait", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
@@ -92,7 +104,8 @@ var _ = Describe("Modify data objects", func() {
 					Timeout: Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataVolume: datavolume.NewBlankDataVolume("blank").Build(),
+					DataVolume:        datavolume.NewBlankDataVolume("blank").Build(),
+					SetOwnerReference: "true",
 				},
 			}),
 			Entry("blank wait", &testconfigs.ModifyDataObjectTestConfig{
@@ -101,8 +114,9 @@ var _ = Describe("Modify data objects", func() {
 					Timeout: Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataVolume:     datavolume.NewBlankDataVolume("blank-wait").Build(),
-					WaitForSuccess: true,
+					DataVolume:        datavolume.NewBlankDataVolume("blank-wait").Build(),
+					WaitForSuccess:    true,
+					SetOwnerReference: "false",
 				},
 			}),
 			Entry("works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{
@@ -383,13 +397,22 @@ var _ = Describe("Modify data objects", func() {
 
 			err = dataobject.WaitForSuccessfulDataSource(f.CdiClient, ds.Namespace, ds.Name, config.GetWaitForDataObjectTimeout())
 			Expect(err).ShouldNot(HaveOccurred())
+
+			if config.TaskData.SetOwnerReference == "true" {
+				Expect(ds.OwnerReferences).To(HaveLen(1), "ds should has owner reference")
+				Expect(ds.OwnerReferences[0].Kind).To(Equal("Pod"), "OwnerReference should have Kind Pod")
+				Expect(ds.OwnerReferences[0].Name).To(HavePrefix("e2e-tests-taskrun-modify-data-object"), "OwnerReference should be binded to correct Pod")
+			} else {
+				Expect(ds.OwnerReferences).To(BeEmpty(), "ds OwnerReference should be empty")
+			}
 		},
 			Entry("blank no wait", &testconfigs.ModifyDataObjectTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					Timeout: Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataSource: datasource.NewDataSource("blank").Build(),
+					DataSource:        datasource.NewDataSource("blank").Build(),
+					SetOwnerReference: "true",
 				},
 			}),
 			Entry("blank wait", &testconfigs.ModifyDataObjectTestConfig{
@@ -398,8 +421,9 @@ var _ = Describe("Modify data objects", func() {
 					Timeout: Timeouts.SmallDVCreation,
 				},
 				TaskData: testconfigs.ModifyDataObjectTaskData{
-					DataSource:     datasource.NewDataSource("blank-wait").Build(),
-					WaitForSuccess: true,
+					DataSource:        datasource.NewDataSource("blank-wait").Build(),
+					WaitForSuccess:    true,
+					SetOwnerReference: "false",
 				},
 			}),
 			Entry("works also in the same namespace as deploy", &testconfigs.ModifyDataObjectTestConfig{

--- a/test/testconfigs/modify-data-object-test-config.go
+++ b/test/testconfigs/modify-data-object-test-config.go
@@ -23,6 +23,7 @@ type ModifyDataObjectTaskData struct {
 	DeleteObjectKind    string
 	Namespace           TargetNamespace
 	dataObjectNamespace string
+	SetOwnerReference   string
 }
 
 type ModifyDataObjectTestConfig struct {
@@ -165,6 +166,12 @@ func (c *ModifyDataObjectTestConfig) GetTaskRun() *pipev1.TaskRun {
 					Value: pipev1.ParamValue{
 						Type:      pipev1.ParamTypeString,
 						StringVal: c.TaskData.dataObjectNamespace,
+					},
+				}, {
+					Name: SetOwnerReference,
+					Value: pipev1.ParamValue{
+						Type:      pipev1.ParamTypeString,
+						StringVal: c.TaskData.SetOwnerReference,
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add ownerReference param to modify-data-object task

This commit adds new param setOwnerReference to modify-data-object tasks. If set to true, the data object will have OwnerReference by TaskRun pod.

**Release note**:
```
chore: add ownerReference param to modify-data-object task
```
