### PR TITLE
[release-v0.17] enable Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchPackagePatterns": [
+        "*"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "assigneesFromCodeOwners": true,
+  "constraints": {
+      "go": "1.20"
+  },
+  "prConcurrentLimit": 3
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
this commit adds renovate settings for creating PRs with only security updates for branch release-v0.17

**Release note**:
```
Enable renovate with security updates only
```
