### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,8 @@
   "lockFileMaintenance": {
     "enabled": false
   },
+  "labels": ["release-note-none"],
+  "extends": [":gitSignOff"],
   "packageRules": [
     {
       "groupName": "all dependencies",


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: update renovate config

Add sign off of commit and no release note label

**Release note**:
```
NONE
```
