### PR TITLE
[release-v0.17] chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,8 @@
       ]
     }
   ],
+  "labels": ["release-note-none"],
+  "extends": [":gitSignOff"],
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: update renovate config

Add sign off of commit and no release note label

**Release note**:
```
NONE
```
