### PR TITLE
chore: enable renovate for older release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["main", "release-v0.17"],
+  "baseBranches": ["main", "release-v0.17", "release-v0.15", "release-v0.13", "release-v0.12"],
   "constraints": {
     "go": "1.22"
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
enable renovate for these branches: release-v0.15, release-v0.13, release-v0.12

**Release note**:
```
NONE
```
