### PR TITLE
fix: lower the go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/kubevirt-tekton-tasks
 
-go 1.22.5
+go 1.22.4
 
 // Kubernetes
 replace (


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: lower the go version in go.mod

The ds automation requires lower version of go specified in go.mod file

**Release note**:
```
NONE
```
