### PR TITLE
chore: update config of renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    ":gitSignOff"
+  ],
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": [
     "main",
@@ -7,9 +10,6 @@
     "release-v0.13",
     "release-v0.12"
   ],
-  "constraints": {
-    "go": "1.22"
-  },
   "prConcurrentLimit": 3,
   "groupName": "all dependencies",
   "groupSlug": "all",
@@ -19,8 +19,8 @@
   "labels": [
     "release-note-none"
   ],
-  "extends": [
-    ":gitSignOff"
+  "ignorePaths": [
+    "modules/tests/**"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: update config of renovate

this commit adds ignorePaths to ignore modules/tests folder, because it updates a lot of packages which are unnecessary in release branches.
Removed constraints with hardcoded go version for main. 
Moved extends to the top of the file.


**Release note**:
```
NONE
```
