### PR TITLE
[release-v0.15] fix: pin tekton version to v0.67.0

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -12,8 +12,7 @@ KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releas
 CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-TEKTON_VERSION=$(curl -s https://api.github.com/repos/tektoncd/operator/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+TEKTON_VERSION="v0.67.0"
 
 SSP_OPERATOR_VERSION=$(curl -s  https://api.github.com/repos/kubevirt/ssp-operator/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: pin tekton version to v0.67.0
e2e are failing because newest operator is not working on OCP 4.14. This commit is pinning the tekton to v0.67.0

**Release note**:
```
NONE
```
