### PR TITLE
[release-v0.13] fix: e2e tests

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -8,8 +8,7 @@ fi
 
 KUBEVIRT_VERSION="v0.59.1"
 
-CDI_VERSION=$(curl -s https://api.github.com/repos/kubevirt/containerized-data-importer/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+CDI_VERSION="v1.55.2"
 
 TEKTON_VERSION="v0.64.0"
 

--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Create VM from template", func() {
 				ExpectedLogs:   ExpectedSuccessfulVMCreation,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
-				TemplateName:      SpacesSmall + "fedora-server-tiny",
+				TemplateName:      SpacesSmall + "fedora-server-medium",
 				TemplateNamespace: SpacesSmall + "openshift" + SpacesSmall,
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-common-template")),

--- a/modules/tests/test/test_suite_test.go
+++ b/modules/tests/test/test_suite_test.go
@@ -66,7 +66,7 @@ func BuildTestSuite() {
 func getCommonTemplatesVersion(templateList *v1.TemplateList) string {
 	var commonTemplatesVersion []int
 	found := false
-	requiredTemplate := "fedora-server-tiny"
+	requiredTemplate := "fedora-server-medium"
 
 	for _, template := range templateList.Items {
 		if strings.HasPrefix(template.Name, requiredTemplate) {


### PR DESCRIPTION
**What this PR does / why we need it**:
[release-v0.13] fix: change fedora template from tiny to medium
fedora tiny was removed from common-templates. The e2e tests need to be adjusted to use fedora medium template.

[release-v0.13] fix: pin cdi version to v1.55.2
CDI changed in newer versions statuses on import of DVs and due to that,
some e2e tests are failing
**Release note**:
```
NONE
```
