### PR TITLE
chore: enable dependency dashboard for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    ":gitSignOff"
+    ":gitSignOff",
+    ":dependencyDashboard"
   ],
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": [


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: enable dependency dashboard for Renovate

**Release note**:
```
NONE
```
