### PR TITLE
chore: add go package to version control for release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,8 @@
     },
     {
       "matchPackageNames": [
-        "golang"
+        "golang",
+        "go"
       ],
       "allowedVersions": "<=1.21",
       "matchBaseBranches": [
@@ -60,7 +61,8 @@
     },
     {
       "matchPackageNames": [
-        "golang"
+        "golang",
+        "go"
       ],
       "allowedVersions": "<=1.20",
       "matchBaseBranches": [
@@ -69,7 +71,8 @@
     },
     {
       "matchPackageNames": [
-        "golang"
+        "golang",
+        "go"
       ],
       "allowedVersions": "<=1.19",
       "matchBaseBranches": [


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: add go package to version control for release branches

Add go package to packageRules so we are able to control which go version is in which branch

**Release note**:
```
NONE

```
