### PR TITLE
[release-v0.12] fix: use template fedora-server-medium in e2e tests

### DIFF
--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -325,7 +325,7 @@ var _ = Describe("Create VM from template", func() {
 				ExpectedLogs:   ExpectedSuccessfulVMCreation,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
-				TemplateName:      SpacesSmall + "fedora-server-tiny",
+				TemplateName:      SpacesSmall + "fedora-server-medium",
 				TemplateNamespace: SpacesSmall + "openshift" + SpacesSmall,
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-common-template")),

--- a/modules/tests/test/test_suite_test.go
+++ b/modules/tests/test/test_suite_test.go
@@ -66,7 +66,7 @@ func BuildTestSuite() {
 func getCommonTemplatesVersion(templateList *v1.TemplateList) string {
 	var commonTemplatesVersion []int
 	found := false
-	requiredTemplate := "fedora-server-tiny"
+	requiredTemplate := "fedora-server-medium"
 
 	for _, template := range templateList.Items {
 		if strings.HasPrefix(template.Name, requiredTemplate) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: use template fedora-server-medium in e2e tests

template fedora-server-tiny was removed and it has to be replaced with fedora-server-medium

**Release note**:
```
NONE
```
