### PR TITLE
refactor: use spec.runStrategy instead of spec.running

### DIFF
--- a/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
+++ b/examples/pipelines/server-deployer/server-deployer-pipeline.yaml
@@ -64,7 +64,7 @@ spec:
               labels:
                 app: flasker-vm
             spec:
-              running: true
+              runStrategy: Always
               template:
                 metadata:
                   labels:

--- a/examples/pipelines/unit-tester/unit-tester-pipeline.yaml
+++ b/examples/pipelines/unit-tester/unit-tester-pipeline.yaml
@@ -36,7 +36,7 @@ spec:
             metadata:
               name: $(params.vmName)
             spec:
-              running: false
+              runStrategy: Halted
               template:
                 metadata:
                   labels:

--- a/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
+++ b/examples/pipelines/virt-sysprep-updater/virt-sysprep-updater-pipeline.yaml
@@ -56,7 +56,7 @@ spec:
               labels:
                 app: virt-sysprep-updated-vm
             spec:
-              running: false
+              runStrategy: Halted
               template:
                 metadata:
                   labels:

--- a/modules/sharedtest/testobjects/alpine-vm.go
+++ b/modules/sharedtest/testobjects/alpine-vm.go
@@ -1,6 +1,8 @@
 package testobjects
 
-import v1 "kubevirt.io/api/core/v1"
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
 
 func NewTestAlpineVM(name string) *TestVM {
 	containerDiskName := "containerdisk"
@@ -30,6 +32,6 @@ func NewTestAlpineVM(name string) *TestVM {
 		},
 	}
 	return (&TestVM{
-		Data: newRandomVirtualMachine(vmi, false),
+		Data: newRandomVirtualMachine(vmi, v1.RunStrategyHalted),
 	}).WithMemory("128Mi")
 }

--- a/modules/sharedtest/testobjects/fedora-cloud-vm.go
+++ b/modules/sharedtest/testobjects/fedora-cloud-vm.go
@@ -1,6 +1,8 @@
 package testobjects
 
-import v1 "kubevirt.io/api/core/v1"
+import (
+	v1 "kubevirt.io/api/core/v1"
+)
 
 func NewTestFedoraCloudVM(name string) *TestVM {
 	cloudConfig := &CloudConfig{
@@ -49,6 +51,6 @@ func NewTestFedoraCloudVM(name string) *TestVM {
 		},
 	}
 	return (&TestVM{
-		Data: newRandomVirtualMachine(vmi, false),
+		Data: newRandomVirtualMachine(vmi, v1.RunStrategyHalted),
 	}).WithMemory("1Gi")
 }

--- a/modules/sharedtest/testobjects/template/cirros-tiny.go
+++ b/modules/sharedtest/testobjects/template/cirros-tiny.go
@@ -50,7 +50,7 @@ objects:
         vm.kubevirt.io/template.version: 0.3.2
       name: '${NAME}'
     spec:
-      running: false
+      runStrategy: Halted
       template:
         metadata:
           labels:

--- a/modules/sharedtest/testobjects/template/fedora-tiny.go
+++ b/modules/sharedtest/testobjects/template/fedora-tiny.go
@@ -74,7 +74,7 @@ objects:
       vm.kubevirt.io/template.version: 0.3.2
     name: ${NAME}
   spec:
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         labels:

--- a/modules/sharedtest/testobjects/template/rhel-tiny.go
+++ b/modules/sharedtest/testobjects/template/rhel-tiny.go
@@ -89,7 +89,7 @@ objects:
           kind: DataSource
           name: ${DATA_SOURCE_NAME}
           namespace: ${DATA_SOURCE_NAMESPACE}
-    running: false
+    runStrategy: Halted
     template:
       metadata:
         annotations:

--- a/modules/sharedtest/testobjects/vm.go
+++ b/modules/sharedtest/testobjects/vm.go
@@ -39,7 +39,7 @@ func newRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	return vmi
 }
 
-func newRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.VirtualMachine {
+func newRandomVirtualMachine(vmi *v1.VirtualMachineInstance, runStrategy v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
 	name := vmi.Name
 	namespace := vmi.Namespace
 	labels := map[string]string{"name": name}
@@ -52,7 +52,7 @@ func newRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 			Namespace: namespace,
 		},
 		Spec: v1.VirtualMachineSpec{
-			Running: &running,
+			RunStrategy: &runStrategy,
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:    labels,
@@ -69,7 +69,7 @@ func newRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 
 func NewTestVM() *TestVM {
 	return &TestVM{
-		Data: newRandomVirtualMachine(newRandomVMI(), false),
+		Data: newRandomVirtualMachine(newRandomVMI(), v1.RunStrategyHalted),
 	}
 }
 

--- a/release/tasks/create-vm-from-manifest/README.md
+++ b/release/tasks/create-vm-from-manifest/README.md
@@ -52,7 +52,7 @@ metadata:
     labels:
         kubevirt.io/vm: vm-fedora
 spec:
-    running: false
+    runStrategy: Halted
     template:
         metadata:
             labels:

--- a/templates/create-vm-from-manifest/examples/vm.yaml
+++ b/templates/create-vm-from-manifest/examples/vm.yaml
@@ -5,7 +5,7 @@ metadata:
     kubevirt.io/vm: vm-fedora
   generateName: vm-fedora-
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       labels:

--- a/test/create_vm_from_manifest_test.go
+++ b/test/create_vm_from_manifest_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Create VM from manifest", func() {
 	})
 
 	Context("with StartVM", func() {
-		DescribeTable("VM is created successfully", func(config *testconfigs.CreateVMTestConfig, phase kubevirtv1.VirtualMachineInstancePhase, running bool) {
+		DescribeTable("VM is created successfully", func(config *testconfigs.CreateVMTestConfig, phase kubevirtv1.VirtualMachineInstancePhase, runStrategy kubevirtv1.VirtualMachineRunStrategy) {
 			f.TestSetup(config)
 
 			expectedVMStub := config.TaskData.GetExpectedVMStubMeta()
@@ -366,7 +366,7 @@ var _ = Describe("Create VM from manifest", func() {
 				phase, config.GetTaskRunTimeout(), false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(*vm.Spec.Running).To(Equal(running), "vm should be in correct running phase")
+			Expect(*vm.Spec.RunStrategy).To(Equal(runStrategy), "vm should be in correct running phase")
 		},
 			Entry("with false StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
@@ -380,7 +380,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "false",
 				},
-			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), kubevirtv1.RunStrategyHalted),
 			Entry("with invalid StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ExpectedLogs: ExpectedSuccessfulVMCreation,
@@ -393,7 +393,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "invalid_value",
 				},
-			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), kubevirtv1.RunStrategyHalted),
 			Entry("with true StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ExpectedLogs: ExpectedSuccessfulVMCreation,
@@ -406,7 +406,7 @@ var _ = Describe("Create VM from manifest", func() {
 						Build(),
 					StartVM: "true",
 				},
-			}, kubevirtv1.Running, true),
+			}, kubevirtv1.Running, kubevirtv1.RunStrategyAlways),
 		)
 	})
 

--- a/test/create_vm_from_template_test.go
+++ b/test/create_vm_from_template_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Create VM from template", func() {
 	})
 
 	Context("with StartVM", func() {
-		DescribeTable("VM is created from template with StartVM attribute", func(config *testconfigs.CreateVMTestConfig, phase kubevirtv1.VirtualMachineInstancePhase, running bool) {
+		DescribeTable("VM is created from template with StartVM attribute", func(config *testconfigs.CreateVMTestConfig, phase kubevirtv1.VirtualMachineInstancePhase, runStrategy kubevirtv1.VirtualMachineRunStrategy) {
 			f.TestSetup(config)
 			template, err := f.TemplateClient.Templates(config.TaskData.Template.Namespace).Create(context.Background(), config.TaskData.Template, v1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -331,7 +331,7 @@ var _ = Describe("Create VM from template", func() {
 			vm, err := vm.WaitForVM(f.KubevirtClient, expectedVMStub.Namespace, expectedVMStub.Name,
 				phase, config.GetTaskRunTimeout(), false)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*vm.Spec.Running).To(Equal(running), "vm should be in correct running phase")
+			Expect(*vm.Spec.RunStrategy).To(Equal(runStrategy), "vm should be in correct running phase")
 		},
 			Entry("with invalid StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
@@ -344,7 +344,7 @@ var _ = Describe("Create VM from template", func() {
 					},
 					StartVM: "invalid_value",
 				},
-			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), kubevirtv1.RunStrategyHalted),
 			Entry("with false StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ExpectedLogs: ExpectedSuccessfulVMCreation,
@@ -356,7 +356,7 @@ var _ = Describe("Create VM from template", func() {
 					},
 					StartVM: "false",
 				},
-			}, kubevirtv1.VirtualMachineInstancePhase(""), false),
+			}, kubevirtv1.VirtualMachineInstancePhase(""), kubevirtv1.RunStrategyHalted),
 			Entry("with true StartVM value", &testconfigs.CreateVMTestConfig{
 				TaskRunTestConfig: testconfigs.TaskRunTestConfig{
 					ExpectedLogs: ExpectedSuccessfulVMCreation,
@@ -368,7 +368,7 @@ var _ = Describe("Create VM from template", func() {
 					},
 					StartVM: "true",
 				},
-			}, kubevirtv1.Running, true),
+			}, kubevirtv1.Running, kubevirtv1.RunStrategyAlways),
 		)
 	})
 

--- a/test/execute_and_cleanup_vm_test.go
+++ b/test/execute_and_cleanup_vm_test.go
@@ -437,7 +437,7 @@ var _ = Describe("Execute in VM / Cleanup VM", func() {
 			Expect(err).Should(HaveOccurred())
 		} else if config.TaskData.Stop {
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*vm.Spec.Running).To(BeFalse())
+			Expect(*vm.Spec.RunStrategy).To(Equal(kubevirtv1.RunStrategyHalted))
 		}
 	},
 		// negative cases


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There is a plan to deprecate spec.running
and instead spec.runStrategy should be
used. Requested by KubeVirt maintainers
to ensure that repositories already have
spec.runStrategy implemented.

Fixes #515.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use spec.runStrategy instead of spec.running
```