### PR TITLE
fix(CNV-50417): enable usage of a custom secret

### DIFF
--- a/release/tasks/disk-uploader/README.md
+++ b/release/tasks/disk-uploader/README.md
@@ -17,6 +17,7 @@ When user runs [KubeVirt Tekton Tasks](https://github.com/kubevirt/kubevirt-tekt
 - **VOLUME_NAME**: The volume name (If source kind is PVC, then volume name is equal to source name)
 - **IMAGE_DESTINATION**: Destination of the image in container registry
 - **PUSH_TIMEOUT**: ContainerDisk push timeout in minutes
+- **SECRET_NAME**: Name of the secret which holds credential for container registry
 
 ### Usage
 

--- a/release/tasks/disk-uploader/disk-uploader.yaml
+++ b/release/tasks/disk-uploader/disk-uploader.yaml
@@ -38,6 +38,9 @@ spec:
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
+  - name: SECRET_NAME
+    description: Name of the secret which holds credential for container registry
+    type: string
   steps:
   - name: disk-uploader-step
     image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
@@ -45,12 +48,12 @@ spec:
     - name: ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:
-          name: disk-uploader-credentials
+          name: $(params.SECRET_NAME)
           key: accessKeyId
     - name: SECRET_KEY
       valueFrom:
         secretKeyRef:
-          name: disk-uploader-credentials
+          name: $(params.SECRET_NAME)
           key: secretKey
     - name: POD_NAMESPACE
       valueFrom:

--- a/templates/disk-uploader/manifests/disk-uploader.yaml
+++ b/templates/disk-uploader/manifests/disk-uploader.yaml
@@ -38,6 +38,9 @@ spec:
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
+  - name: SECRET_NAME
+    description: Name of the secret which holds credential for container registry
+    type: string
   steps:
   - name: disk-uploader-step
     image: "{{ main_image }}:{{ version }}"
@@ -45,12 +48,12 @@ spec:
     - name: ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:
-          name: disk-uploader-credentials
+          name: $(params.SECRET_NAME)
           key: accessKeyId
     - name: SECRET_KEY
       valueFrom:
         secretKeyRef:
-          name: disk-uploader-credentials
+          name: $(params.SECRET_NAME)
           key: secretKey
     - name: POD_NAMESPACE
       valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add a new parameter secret-name which allows user to define another secret than only "kubevirt-disk-uploader-credentials-tekton".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a new secret-name parameter
```