### PR TITLE
fix: hardcode instance-types version to 1.1.0

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -18,8 +18,10 @@ TEKTON_VERSION=$(curl -s https://api.github.com/repos/tektoncd/operator/releases
 SSP_OPERATOR_VERSION=$(curl -s  https://api.github.com/repos/kubevirt/ssp-operator/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
-INSTANCE_TYPES_VERSION=$(curl -s  https://api.github.com/repos/kubevirt/common-instancetypes/releases | \
-            jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
+INSTANCE_TYPES_VERSION="v1.1.0"
+            # uncomment these lines when kubevirt 1.4 is released
+            #$(curl -s  https://api.github.com/repos/kubevirt/common-instancetypes/releases | \
+            #jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
 
 if kubectl get templates > /dev/null 2>&1; then
   # okd


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: hardcode instance-types version to 1.1.0

newest instance types (v1.2.0) can't work with kubevirt 1.3.1. We have to wait until the new kubevirt version is out

**Release note**:
```
NONE
```
