### PR TITLE
feat: add timeout parameter to modify-data-object task

### DIFF
--- a/modules/modify-data-object/pkg/dataobject/provider.go
+++ b/modules/modify-data-object/pkg/dataobject/provider.go
@@ -248,7 +248,7 @@ func (d *DataObjectCreator) CreateDataObject() (*unstructured.Unstructured, erro
 }
 
 func (d *DataObjectCreator) waitForSuccessDv(namespace, name string) error {
-	return wait.PollImmediate(constants.PollInterval, constants.PollTimeout, func() (bool, error) {
+	return wait.PollImmediate(constants.PollInterval, d.cliOptions.GetScriptTimeout(), func() (bool, error) {
 		dv, err := d.dataObjectProvider.GetDv(namespace, name)
 
 		if errors.IsNotFound(err) {
@@ -285,7 +285,7 @@ func (d *DataObjectCreator) waitForSuccessDv(namespace, name string) error {
 }
 
 func (d *DataObjectCreator) waitForSuccessDs(namespace, name string) error {
-	return wait.PollImmediate(constants.PollInterval, constants.PollTimeout, func() (bool, error) {
+	return wait.PollImmediate(constants.PollInterval, d.cliOptions.GetScriptTimeout(), func() (bool, error) {
 		ds, err := d.dataObjectProvider.GetDs(namespace, name)
 		if err != nil {
 			return false, err

--- a/modules/modify-data-object/pkg/utils/parse/clioptions_test.go
+++ b/modules/modify-data-object/pkg/utils/parse/clioptions_test.go
@@ -41,6 +41,11 @@ var _ = Describe("CLIOptions", func() {
 					DataObjectManifest: testDvManifest1,
 					Output:             "non-existing",
 				}),
+			Entry("wrong timeout", "invalid duration \"wrong timeout\"",
+				&parse.CLIOptions{
+					DataObjectManifest: testDvManifest1,
+					Timeout:            "wrong timeout",
+				}),
 		)
 	})
 
@@ -51,6 +56,7 @@ var _ = Describe("CLIOptions", func() {
 			Entry("with yaml output", &parse.CLIOptions{
 				DataObjectManifest:  testDvManifest1,
 				DataObjectNamespace: testStrDataObjectNamespace1,
+				Timeout:             "1h1m1s",
 				Output:              "yaml",
 			}),
 			Entry("with json output", &parse.CLIOptions{
@@ -81,6 +87,7 @@ var _ = Describe("CLIOptions", func() {
 			Entry("with yaml output", &parse.CLIOptions{
 				DataObjectManifest:  testDsManifest,
 				DataObjectNamespace: testStrDataObjectNamespace1,
+				Timeout:             "1h1m1s",
 				Output:              "yaml",
 			}),
 			Entry("with json output", &parse.CLIOptions{

--- a/release/tasks/modify-data-object/README.md
+++ b/release/tasks/modify-data-object/README.md
@@ -11,6 +11,7 @@ This task modifies a data object (DataVolumes or DataSources).
 - **deleteObject**: Set to `true` or `false` if task should delete the specified DataVolume, DataSource or PersistentVolumeClaim. If set to 'true' the ds/dv/pvc will be deleted and all other parameters are ignored.
 - **deleteObjectKind**: Kind of the data object to delete. This parameter is used only for Delete operation.
 - **deleteObjectName**: Name of the data object to delete. This parameter is used only for Delete operation.
+- **timeout**: When waitForSuccess parameter is set to true, this parameter defines how long the task will wait until it timeouts. Should be in a 3h2m1s format.
 - **setOwnerReference**: Set owner reference to the new object created by the task run pod. Allowed values true/false
   
 ### Results

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -50,6 +50,10 @@ spec:
       description: Name of the data object to delete. This parameter is used only for Delete operation.
       default: ""
       type: string
+    - description: When waitForSuccess parameter is set to true, this parameter defines how long the task will wait until it timeouts. Should be in a 3h2m1s format.
+      name: timeout
+      type: string
+      default: "1h"
     - name: setOwnerReference
       description: Set owner reference to the new object created by the task run pod. Allowed values true/false
       type: string
@@ -83,6 +87,8 @@ spec:
           value: $(params.deleteObjectName)
         - name: SET_OWNER_REFERENCE
           value: $(params.setOwnerReference)
+        - name: TIMEOUT
+          value: $(params.timeout)
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -50,6 +50,10 @@ spec:
       description: Name of the data object to delete. This parameter is used only for Delete operation.
       default: ""
       type: string
+    - description: When waitForSuccess parameter is set to true, this parameter defines how long the task will wait until it timeouts. Should be in a 3h2m1s format.
+      name: timeout
+      type: string
+      default: "1h"
     - name: setOwnerReference
       description: Set owner reference to the new object created by the task run pod. Allowed values true/false
       type: string
@@ -83,6 +87,8 @@ spec:
           value: $(params.deleteObjectName)
         - name: SET_OWNER_REFERENCE
           value: $(params.setOwnerReference)
+        - name: TIMEOUT
+          value: $(params.timeout)
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add timeout parameter to modify-data-object tasks

When importing data object from slow server and wait-for-success param is set to true, one hour of timeout might not be enough. This commit introduces new parameter timeout where user can increase / decrease time necessary to import data object. Defaul value is 1 hour.

**Release note**:
```
feat: add timeout parameter to modify-data-object tasks
```
