### PR TITLE
feat: enable VMPersistentState feature gate in kubevirt

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -40,7 +40,7 @@ kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEV
 
 kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
 
-kubectl patch kubevirt kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["DataVolumes"]}}}}'
+kubectl patch kubevirt kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["VMPersistentState"]}}}}'
 
 # Deploy Storage
 kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: enable VMPersistentState feature gate in kubevirt

windows VMs (run in e2e pipeline tests) requires this fg.

**Release note**:
```
NONE

```
