### PR TITLE
fix(CNV-40411): wrong export source kinds

### DIFF
--- a/modules/disk-uploader/pkg/vmexport/vmexport.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport.go
@@ -93,9 +93,9 @@ func GetRawDiskUrlFromVolumes(client kubecli.KubevirtClient, namespace, name, vo
 
 func GetLabelsFromExportSource(virtClient kubecli.KubevirtClient, exportSourceKind, exportSourceNamespace, exportSourceName, volumeName string) (map[string]string, error) {
 	switch exportSourceKind {
-	case "VirtualMachine", "VirtualMachineSnapshot":
+	case sourceVM, sourceVMSnapshot:
 		return getLabelsFromVirtualMachineOrSnapshot(virtClient, exportSourceNamespace, volumeName)
-	case "PersistentVolumeClaim":
+	case sourcePVC:
 		return getLabelsFromPVC(virtClient, exportSourceNamespace, exportSourceName)
 	default:
 		return nil, fmt.Errorf("unsupported source kind: %s", exportSourceKind)

--- a/modules/disk-uploader/pkg/vmexport/vmexport_test.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport_test.go
@@ -216,8 +216,8 @@ var _ = Describe("VMExport", func() {
 			Expect(labels).To(HaveKeyWithValue(defaultInstanceType, "cx1.2xlarge"))
 			Expect(labels).To(HaveKeyWithValue(defaultPreference, "fedora"))
 		},
-			Entry("for VirtualMachine", "VirtualMachine"),
-			Entry("for VirtualMachineSnapshot", "VirtualMachineSnapshot"),
+			Entry("for VirtualMachine", "vm"),
+			Entry("for VirtualMachineSnapshot", "vmsnapshot"),
 		)
 
 		DescribeTable("should return labels from pvc if there is no datavolume", func(resourceType string) {
@@ -238,8 +238,8 @@ var _ = Describe("VMExport", func() {
 			Expect(labels).To(HaveKeyWithValue(defaultInstanceType, "cx1.2xlarge"))
 			Expect(labels).To(HaveKeyWithValue(defaultPreference, "fedora"))
 		},
-			Entry("for VirtualMachine", "VirtualMachine"),
-			Entry("for VirtualMachineSnapshot", "VirtualMachineSnapshot"),
+			Entry("for VirtualMachine", "vm"),
+			Entry("for VirtualMachineSnapshot", "vmsnapshot"),
 		)
 
 		It("should return labels directly from pvc", func() {
@@ -255,15 +255,15 @@ var _ = Describe("VMExport", func() {
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			labels, err := vmexport.GetLabelsFromExportSource(virtClient, "PersistentVolumeClaim", namespace, "example-pvc", "")
+			labels, err := vmexport.GetLabelsFromExportSource(virtClient, "pvc", namespace, "example-pvc", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(labels).To(HaveKeyWithValue(defaultInstanceType, "cx1.2xlarge"))
 			Expect(labels).To(HaveKeyWithValue(defaultPreference, "fedora"))
 		})
 
 		It("should return unsupported source kind error", func() {
-			labels, err := vmexport.GetLabelsFromExportSource(virtClient, "VirtualMachineInstance", namespace, name, "disk-volume-1")
-			Expect(err).To(MatchError("unsupported source kind: VirtualMachineInstance"))
+			labels, err := vmexport.GetLabelsFromExportSource(virtClient, "vmi", namespace, name, "disk-volume-1")
+			Expect(err).To(MatchError("unsupported source kind: vmi"))
 			Expect(labels).To(BeNil())
 		})
 
@@ -272,9 +272,9 @@ var _ = Describe("VMExport", func() {
 			Expect(err).To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 			Expect(labels).To(BeNil())
 		},
-			Entry("for VirtualMachine with missing DV and PVC", "VirtualMachine", "example-volume"),
-			Entry("for VirtualMachineSnapshot with missing DV and PVC", "VirtualMachineSnapshot", "example-volume"),
-			Entry("for PersistentVolumeClaim with missing PVC", "PersistentVolumeClaim", ""),
+			Entry("for VirtualMachine with missing DV and PVC", "vm", "example-volume"),
+			Entry("for VirtualMachineSnapshot with missing DV and PVC", "vmsnapshot", "example-volume"),
+			Entry("for PersistentVolumeClaim with missing PVC", "pvc", ""),
 		)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There is a check of the export source kind
before getting labels from the export
source. It expects kinds "VirutalMachine",
"VirtualMachineSnapshot" or only
"PersistentVolumeClaim". Instead,
it should be "vm", "vmsnapshot" or
only "pvc".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```