### PR TITLE
fix(CNV-52011): create objects with random names

### DIFF
--- a/modules/disk-uploader/pkg/secrets/secrets_test.go
+++ b/modules/disk-uploader/pkg/secrets/secrets_test.go
@@ -50,12 +50,12 @@ var _ = Describe("VMExport", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = secrets.CreateVirtualMachineExportSecret(kubeClient, namespace, name)
+			_, err = secrets.CreateVirtualMachineExportSecret(kubeClient, namespace, name)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return error when set pod owner reference failed", func() {
-			err := secrets.CreateVirtualMachineExportSecret(kubeClient, namespace, name)
+			_, err := secrets.CreateVirtualMachineExportSecret(kubeClient, namespace, name)
 			Expect(err).To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 		})
 	})

--- a/modules/disk-uploader/pkg/vmexport/vmexport_test.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport_test.go
@@ -73,7 +73,7 @@ var _ = Describe("VMExport", func() {
 				)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = vmexport.CreateVirtualMachineExport(virtClient, resource, namespace, name)
+				_, err = vmexport.CreateVirtualMachineExport(virtClient, resource, namespace, name, "fake-secret")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeFalse())
 			},
@@ -83,12 +83,12 @@ var _ = Describe("VMExport", func() {
 		)
 
 		It("should return error when export-source-kind invalid", func() {
-			err := vmexport.CreateVirtualMachineExport(virtClient, "fake", namespace, name)
+			_, err := vmexport.CreateVirtualMachineExport(virtClient, "fake", namespace, name, "fake-secret")
 			Expect(err).To(MatchError("invalid export-source-kind: fake, must be one of vm, vmsnapshot, pvc"))
 		})
 
 		It("should return error when set pod owner reference failed", func() {
-			err := vmexport.CreateVirtualMachineExport(virtClient, "vm", namespace, name)
+			_, err := vmexport.CreateVirtualMachineExport(virtClient, "vm", namespace, name, "fake-secret")
 			Expect(err).To(MatchError(errors.IsNotFound, "errors.IsNotFound"))
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When running disk-uploader it creates
VMExport object and VMExport secret
to store a token that required by the
Export API endpoints.

Currently the name of VMExport object
and VMExport secret is not random
generated and will fail to be created
again if the disk-uploader (as a Tekton
Task) will run twice. As a result, it
throws a panic error that causes the
failure of the execution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #542.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Generate random name of objects
```