### PR TITLE
fix(CNV-40411): add new disk-uploader roles

### DIFF
--- a/examples/pipelines/disk-uploader/disk-uploader-role.yaml
+++ b/examples/pipelines/disk-uploader/disk-uploader-role.yaml
@@ -4,15 +4,18 @@ kind: Role
 metadata:
   name: disk-uploader
 rules:
-- apiGroups: ["kubevirt.io"]
-  resources: ["virtualmachines"]
-  verbs: ["get", "create", "patch"]
 - apiGroups: ["export.kubevirt.io"]
   resources: ["virtualmachineexports"]
   verbs: ["get", "create"]
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes"]
+  verbs: ["get"]
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "create"]
 - apiGroups: [""]
   resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
   verbs: ["get"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The disk-uploader should be able to
access Data Volume or Presistent
Volume Claim to get the InstanceType
and Preference labels from them,
and set in the newly created
containerDisk.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```