### PR TITLE
chore: bump versions from v0.22.0 to v0.23.0

### DIFF
--- a/release/pipelines/windows-customize/README.md
+++ b/release/pipelines/windows-customize/README.md
@@ -61,7 +61,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 EOF
 ```
@@ -92,7 +92,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 EOF
 ```
@@ -121,7 +121,7 @@ spec:
         -   name: name
             value: windows-customize
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 EOF
 ```

--- a/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-customize/pipelineruns/pipelineruns.yaml
@@ -16,7 +16,7 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.22.0
+        value: v0.23.0
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -44,7 +44,7 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.22.0
+        value: v0.23.0
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -70,4 +70,4 @@ spec:
       - name: name
         value: windows-customize
       - name: version
-        value: v0.22.0
+        value: v0.23.0

--- a/release/pipelines/windows-customize/windows-customize.yaml
+++ b/release/pipelines/windows-customize/windows-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: windows-customize
 spec:
   description: >-
@@ -92,7 +92,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       params:
         - name: manifest
           value: |-
@@ -162,7 +162,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       runAfter:
         - copy-vm-root-disk
     - name: wait-for-vmi-status
@@ -190,7 +190,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: create-datasource-root-disk
       runAfter:
         - wait-for-vmi-status
@@ -206,7 +206,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       params:
         - name: manifest
           value: |-
@@ -251,7 +251,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: delete-imported-configmaps
       params:
         - name: SCRIPT

--- a/release/pipelines/windows-efi-installer/README.md
+++ b/release/pipelines/windows-efi-installer/README.md
@@ -105,7 +105,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
     taskRunSpecs:
     -   pipelineTaskName: modify-windows-iso-file
@@ -146,7 +146,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
     taskRunSpecs:
     -   pipelineTaskName: modify-windows-iso-file
@@ -188,7 +188,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
     taskRunSpecs:
     -   pipelineTaskName: modify-windows-iso-file
@@ -230,7 +230,7 @@ spec:
         -   name: name
             value: windows-efi-installer
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
     taskRunSpecs:
     -   pipelineTaskName: modify-windows-iso-file

--- a/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
+++ b/release/pipelines/windows-efi-installer/pipelineruns/pipelineruns.yaml
@@ -21,7 +21,7 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.22.0
+        value: v0.23.0
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
@@ -59,7 +59,7 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.22.0
+        value: v0.23.0
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
@@ -98,7 +98,7 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.22.0
+        value: v0.23.0
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:
@@ -137,7 +137,7 @@ spec:
       - name: name
         value: windows-efi-installer
       - name: version
-        value: v0.22.0
+        value: v0.23.0
   taskRunSpecs:
     - pipelineTaskName: "modify-windows-iso-file"
       podTemplate:

--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: windows-efi-installer
 spec:
   description: >-
@@ -135,7 +135,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: modify-windows-iso-file
       when:
         - input: "$(params.useBiosMode)"
@@ -159,7 +159,7 @@ spec:
           - name: name
             value: modify-windows-iso-file
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: create-vm-root-disk
       runAfter:
         - import-autounattend-configmaps
@@ -175,7 +175,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       params:
         - name: manifest
           value: |-
@@ -266,7 +266,7 @@ spec:
           - name: name
             value: create-vm-from-manifest
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: wait-for-vmi-status
       params:
         - name: vmiName
@@ -291,7 +291,7 @@ spec:
           - name: name
             value: wait-for-vmi-status
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       timeout: 2h0m0s
     - name: create-datasource-root-disk
       runAfter:
@@ -308,7 +308,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       params:
         - name: manifest
           value: |-
@@ -352,7 +352,7 @@ spec:
           - name: name
             value: cleanup-vm
           - name: version
-            value: v0.22.0
+            value: v0.23.0
       timeout: 10m0s
     - name: delete-imported-iso
       params:
@@ -376,7 +376,7 @@ spec:
           - name: name
             value: modify-data-object
           - name: version
-            value: v0.22.0
+            value: v0.23.0
     - name: delete-imported-configmaps
       params:
         - name: SCRIPT

--- a/release/tasks/cleanup-vm/README.md
+++ b/release/tasks/cleanup-vm/README.md
@@ -77,7 +77,7 @@ spec:
         -   name: name
             value: cleanup-vm
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/release/tasks/cleanup-vm/cleanup-vm.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: cleanup-vm
 spec:
   description: >-
@@ -60,7 +60,7 @@ spec:
       default: ""
   steps:
     - name: execute-in-vm
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/cleanup-vm/examples/taskruns/cleanup-vm-taskrun-resolver.yaml
+++ b/release/tasks/cleanup-vm/examples/taskruns/cleanup-vm-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: cleanup-vm
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: vmName
       value: vm-example

--- a/release/tasks/create-vm-from-manifest/README.md
+++ b/release/tasks/create-vm-from-manifest/README.md
@@ -39,7 +39,7 @@ spec:
         -   name: name
             value: create-vm-from-manifest
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: create-vm-from-manifest
 spec:
   description: >-
@@ -55,7 +55,7 @@ spec:
       description: The namespace of a VM that was created.
   steps:
     - name: createvm
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - create-vm
       args:

--- a/release/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun-resolver.yaml
+++ b/release/tasks/create-vm-from-manifest/examples/taskruns/create-vm-from-manifest-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: create-vm-from-manifest
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
   - name: manifest
     value: |

--- a/release/tasks/disk-uploader/README.md
+++ b/release/tasks/disk-uploader/README.md
@@ -50,7 +50,7 @@ spec:
         -   name: name
             value: disk-uploader
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 
 ```

--- a/release/tasks/disk-uploader/disk-uploader.yaml
+++ b/release/tasks/disk-uploader/disk-uploader.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: disk-uploader
 spec:
   description: >-
@@ -43,7 +43,7 @@ spec:
     type: string
   steps:
   - name: disk-uploader-step
-    image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+    image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
     env:
     - name: ACCESS_KEY_ID
       valueFrom:

--- a/release/tasks/disk-uploader/examples/taskruns/disk-uploader-taskrun-resolver.yaml
+++ b/release/tasks/disk-uploader/examples/taskruns/disk-uploader-taskrun-resolver.yaml
@@ -15,7 +15,7 @@ spec:
     - name: name
       value: disk-uploader
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
   - name: EXPORT_SOURCE_KIND
     value: vm

--- a/release/tasks/disk-virt-customize/README.md
+++ b/release/tasks/disk-virt-customize/README.md
@@ -38,7 +38,7 @@ spec:
         -   name: name
             value: disk-virt-customize
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/release/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: disk-virt-customize
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-customize
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.23.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-customize/examples/taskruns/disk-virt-customize-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: disk-virt-customize
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: pvc
       value: example-pvc

--- a/release/tasks/disk-virt-sysprep/README.md
+++ b/release/tasks/disk-virt-sysprep/README.md
@@ -38,7 +38,7 @@ spec:
         -   name: name
             value: disk-virt-sysprep
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: disk-virt-sysprep
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       default: ""
   steps:
     - name: run-virt-sysprep
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.23.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
+++ b/release/tasks/disk-virt-sysprep/examples/taskruns/disk-virt-sysprep-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: disk-virt-sysprep
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: pvc
       value: example-pvc

--- a/release/tasks/execute-in-vm/README.md
+++ b/release/tasks/execute-in-vm/README.md
@@ -67,7 +67,7 @@ spec:
         -   name: name
             value: execute-in-vm
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun-resolver.yaml
+++ b/release/tasks/execute-in-vm/examples/taskruns/execute-in-vm-with-ssh-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: execute-in-vm
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: vmName
       value: vm-example

--- a/release/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/release/tasks/execute-in-vm/execute-in-vm.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: execute-in-vm
 spec:
   description: >-
@@ -47,7 +47,7 @@ spec:
       default: ""
   steps:
     - name: execute-in-vm
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/generate-ssh-keys/README.md
+++ b/release/tasks/generate-ssh-keys/README.md
@@ -50,7 +50,7 @@ spec:
         -   name: name
             value: generate-ssh-keys
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun-resolver.yaml
+++ b/release/tasks/generate-ssh-keys/examples/taskruns/generate-ssh-keys-advanced-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: generate-ssh-keys
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: publicKeySecretName
       value: my-client-public-secret

--- a/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: generate-ssh-keys
 spec:
   description: >-
@@ -57,7 +57,7 @@ spec:
       description: The namespace of a private key secret.
   steps:
     - name: generate-ssh-keys
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - entrypoint
       args:

--- a/release/tasks/modify-data-object/README.md
+++ b/release/tasks/modify-data-object/README.md
@@ -44,7 +44,7 @@ spec:
         -   name: name
             value: modify-data-object
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun-resolver.yaml
+++ b/release/tasks/modify-data-object/examples/taskruns/modify-data-object-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: modify-data-object
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: waitForSuccess
       value: 'true'

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: modify-data-object
 spec:
   description: >-
@@ -65,7 +65,7 @@ spec:
       description: The namespace of the data object that was created.
   steps:
     - name: modify-data-object
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - modify-data-object
       args:

--- a/release/tasks/modify-windows-iso-file/README.md
+++ b/release/tasks/modify-windows-iso-file/README.md
@@ -32,7 +32,7 @@ spec:
         -   name: name
             value: modify-windows-iso-file
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun-resolver.yaml
+++ b/release/tasks/modify-windows-iso-file/examples/taskruns/modify-windows-iso-file-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: modify-windows-iso-file
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
   - name: pvcName
     value: w11

--- a/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: modify-windows-iso-file
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.23.0"
       script: |
         #!/bin/bash
         set -x
@@ -87,7 +87,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       script: |
         #!/bin/bash
         set -ex
@@ -114,7 +114,7 @@ spec:
         capabilities:
           drop:
           - "ALL"
-      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.23.0"
       script: |
         #!/bin/bash
         set -x

--- a/release/tasks/wait-for-vmi-status/README.md
+++ b/release/tasks/wait-for-vmi-status/README.md
@@ -36,7 +36,7 @@ spec:
         -   name: name
             value: wait-for-vmi-status
         -   name: version
-            value: v0.22.0
+            value: v0.23.0
         resolver: hub
 ```
 

--- a/release/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun-resolver.yaml
+++ b/release/tasks/wait-for-vmi-status/examples/taskruns/wait-for-vmi-status-taskrun-resolver.yaml
@@ -16,7 +16,7 @@ spec:
     - name: name
       value: wait-for-vmi-status
     - name: version
-      value: v0.22.0
+      value: v0.23.0
   params:
     - name: vmiName
       value: example-vm

--- a/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -16,7 +16,7 @@ metadata:
       - url: https://kubevirt.io/
     artifacthub.io/category: integration-delivery
   labels:
-    app.kubernetes.io/version: v0.22.0
+    app.kubernetes.io/version: v0.23.0
   name: wait-for-vmi-status
 spec:
   description: >-
@@ -39,7 +39,7 @@ spec:
       description: A label selector expression to decide if the VirtualMachineInstance (VMI) is in a failed state. Eg. "status.phase in (Failed, Unknown)". It is evaluated on each VMI update and will result in this task failing if true.
   steps:
     - name: wait-for-vmi-status
-      image: "quay.io/kubevirt/tekton-tasks:v0.22.0"
+      image: "quay.io/kubevirt/tekton-tasks:v0.23.0"
       command:
         - entrypoint
       env:

--- a/scripts/makefile-snippets/makefile-release.mk
+++ b/scripts/makefile-snippets/makefile-release.mk
@@ -1,2 +1,2 @@
 #current version of tekton tasks
-export RELEASE_VERSION ?=v0.22.0
+export RELEASE_VERSION ?=v0.23.0


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: bump versions from v0.22.0 to v0.23.0

this commit updates all versions to v0.23.0

**Release note**:
```
NONE
```
