### PR TITLE
fix(CNV-53189): make PUSH_TIMEOUT an optional param

### DIFF
--- a/release/tasks/disk-uploader/README.md
+++ b/release/tasks/disk-uploader/README.md
@@ -37,8 +37,6 @@ spec:
         value: example-dv
     -   name: IMAGE_DESTINATION
         value: quay.io/kubevirt/example-vm-exported:latest
-    -   name: PUSH_TIMEOUT
-        value: 120
     taskRef:
         params:
         -   name: catalog

--- a/release/tasks/disk-uploader/disk-uploader.yaml
+++ b/release/tasks/disk-uploader/disk-uploader.yaml
@@ -38,6 +38,7 @@ spec:
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
+    default: "120"
   - name: SECRET_NAME
     description: Name of the secret which holds credential for container registry
     type: string

--- a/release/tasks/disk-uploader/examples/taskruns/disk-uploader-taskrun-resolver.yaml
+++ b/release/tasks/disk-uploader/examples/taskruns/disk-uploader-taskrun-resolver.yaml
@@ -25,5 +25,3 @@ spec:
     value: example-dv
   - name: IMAGE_DESTINATION
     value: quay.io/kubevirt/example-vm-exported:latest
-  - name: PUSH_TIMEOUT
-    value: 120

--- a/templates/disk-uploader/examples/disk-uploader-taskrun.yaml
+++ b/templates/disk-uploader/examples/disk-uploader-taskrun.yaml
@@ -25,5 +25,3 @@ spec:
     value: example-dv
   - name: IMAGE_DESTINATION
     value: quay.io/kubevirt/example-vm-exported:latest
-  - name: PUSH_TIMEOUT
-    value: 120

--- a/templates/disk-uploader/manifests/disk-uploader.yaml
+++ b/templates/disk-uploader/manifests/disk-uploader.yaml
@@ -38,6 +38,7 @@ spec:
   - name: PUSH_TIMEOUT
     description: ContainerDisk push timeout in minutes
     type: string
+    default: "120"
   - name: SECRET_NAME
     description: Name of the secret which holds credential for container registry
     type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Tekton parameter PUSH_TIMEOUT is not required
and can use default value if not set, which is
timeout of 2 hours (120 minutes).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
PUSH_TIMEOUT parameter is optional.
```
