### PR TITLE
fix(CNV-54663): show status of used export sources

### DIFF
--- a/cmd/disk-uploader/main.go
+++ b/cmd/disk-uploader/main.go
@@ -50,7 +50,7 @@ func run(opts parse.CLIOptions, k8sClient kubernetes.Interface, virtClient kubec
 		return "", err
 	}
 
-	log.Logger().Info("Waiting for VirtualMachineExport status to be ready...")
+	log.Logger().Info("Waiting for VirtualMachineExport object status...")
 
 	if err := vmexport.WaitUntilVirtualMachineExportReady(virtClient, namespace, vmExport.Name); err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently disk-uploader will always show
ready status, and there is no indication
of pending status that could mean of an
used export source (e.g. an used PVC that
is not available to be exported).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Show status of used export sources.
```