### PR TITLE
feat: do not exit with error when tekton result folder does not exists in disk-uploader

### DIFF
--- a/cmd/disk-uploader/main.go
+++ b/cmd/disk-uploader/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 
 	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-uploader/pkg/certificate"
@@ -153,6 +155,15 @@ func main() {
 	results := map[string]string{constants.DigestResultName: imageDigest}
 
 	log.Logger().Debug("recording results", zap.Reflect("results", results))
+
+	if err := res.TektonResultDirExists(); err != nil {
+		log.Logger().Error("something happened while retrieving Tekton result folder")
+		if errors.Is(err, fs.ErrNotExist) {
+			os.Exit(0)
+		} else {
+			os.Exit(constants.WriteResultsExitCode)
+		}
+	}
 
 	if err := res.RecordResults(results); err != nil {
 		log.Logger().Error(err.Error())

--- a/modules/shared/pkg/results/results.go
+++ b/modules/shared/pkg/results/results.go
@@ -1,9 +1,10 @@
 package results
 
 import (
-	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/env"
-	"io/ioutil"
+	"os"
 	"path/filepath"
+
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/env"
 )
 
 func RecordResults(results map[string]string) error {
@@ -17,10 +18,16 @@ func RecordResultsIn(destination string, results map[string]string) error {
 
 	for resKey, resVal := range results {
 		filename := filepath.Join(destination, resKey)
-		err := ioutil.WriteFile(filename, []byte(resVal), 0644)
+		err := os.WriteFile(filename, []byte(resVal), 0644)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func TektonResultDirExists() error {
+	_, err := os.Stat(env.GetTektonResultsDir())
+
+	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: do not exit with error when tekton result folder does not exists in disk-uploader

Disk uploader binary can be triggered via Tekton Tasks or via OCP UI in
disk uploader feature. When UI triggers the binary, binary is looking for
Tekton result folder, which does not exist and ends with error.
If the Tekton result folder is not found, the binary will just exit with
0.
**Release note**:
```
feat: do not exit with error when tekton result folder does not exists in disk-uploader
```
