### PR TITLE
[release-v0.16] fix:insert tag in common templates URL in deploy resource script

### DIFF
--- a/automation/e2e-deploy-resources.sh
+++ b/automation/e2e-deploy-resources.sh
@@ -22,7 +22,7 @@ if kubectl get templates > /dev/null 2>&1; then
   # okd
   COMMON_TEMPLATES_VERSION=$(curl -s https://api.github.com/repos/kubevirt/common-templates/releases | \
             jq '.[] | select(.prerelease==false) | .tag_name' | sort -V | tail -n1 | tr -d '"')
-  oc apply -n openshift -f "https://github.com/kubevirt/common-templates/releases/download/${COMMON_TEMPLATES_VERSION}/common-templates.yaml"
+  oc apply -n openshift -f "https://github.com/kubevirt/common-templates/releases/download/${COMMON_TEMPLATES_VERSION}/common-templates-${COMMON_TEMPLATES_VERSION}.yaml"
 
   oc new-project tekton-pipelines
 fi
@@ -71,7 +71,7 @@ kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 10m
 kubectl wait -n kubevirt deployment ssp-operator --for condition=Available --timeout 10m
 
 kubectl create -f - <<EOF
-apiVersion: ssp.kubevirt.io/v1beta1
+apiVersion: ssp.kubevirt.io/v1beta3
 kind: SSP
 metadata:
   name: ssp-sample

--- a/modules/tests/test/create_vm_from_template_test.go
+++ b/modules/tests/test/create_vm_from_template_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Create VM from template", func() {
 				ExpectedLogs:   ExpectedSuccessfulVMCreation,
 			},
 			TaskData: testconfigs.CreateVMTaskData{
-				TemplateName:      SpacesSmall + "fedora-server-tiny",
+				TemplateName:      SpacesSmall + "fedora-server-medium",
 				TemplateNamespace: SpacesSmall + "openshift" + SpacesSmall,
 				TemplateParams: []string{
 					testtemplate.TemplateParam(testtemplate.NameParam, E2ETestsRandomName("vm-from-common-template")),

--- a/modules/tests/test/test_suite_test.go
+++ b/modules/tests/test/test_suite_test.go
@@ -66,7 +66,7 @@ func BuildTestSuite() {
 func getCommonTemplatesVersion(templateList *v1.TemplateList) string {
 	var commonTemplatesVersion []int
 	found := false
-	requiredTemplate := "fedora-server-tiny"
+	requiredTemplate := "fedora-server-medium"
 
 	for _, template := range templateList.Items {
 		if strings.HasPrefix(template.Name, requiredTemplate) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix:insert tag in common templates URL in deploy resource script

change ssp api version

update version of fedora template used in e2e tests

**Release note**:
```release-note
NONE
```
