### PR TITLE
feat: increate poll interval from 15 seconds to 60 seconds

### DIFF
--- a/modules/disk-uploader/pkg/vmexport/vmexport.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport.go
@@ -52,7 +52,7 @@ func CreateVirtualMachineExport(virtClient kubecli.KubevirtClient, exportSourceK
 }
 
 func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, namespace, name string) error {
-	pollInterval := 15 * time.Second
+	pollInterval := 60 * time.Second
 	pollTimeout := 3600 * time.Second
 	poller := func(ctx context.Context) (bool, error) {
 		vmExport, err := client.VirtualMachineExport(namespace).Get(ctx, name, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: increate poll interval from 15 seconds to 60 seconds

the 15 seconds poll intervall is too short and if user tries to export bigger disk, it puts too much messages in the log. The value is increased to 60 seconds

```release-note
NONE
```
