### PR TITLE
fix: when vmExport is in skipped phase, exit the disk uploader task

### DIFF
--- a/modules/disk-uploader/pkg/vmexport/vmexport.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport.go
@@ -63,6 +63,11 @@ func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, namespace
 		if vmExport.Status != nil {
 			log.Logger().Info("VirtualMachineExport object status", zap.String("status", string(vmExport.Status.Phase)))
 
+			if vmExport.Status.Phase == v1beta1.Skipped {
+				log.Logger().Error("VirtualMachineExport is in Skipped state, and can't be exported - exiting.")
+				return false, fmt.Errorf("vm export is in skipped phase")
+			}
+
 			if vmExport.Status.Phase == v1beta1.Ready {
 				log.Logger().Info("VirtualMachineExport is in Ready state, and export source is not longer used")
 				return true, nil

--- a/modules/disk-uploader/pkg/vmexport/vmexport_test.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport_test.go
@@ -114,6 +114,25 @@ var _ = Describe("VMExport", func() {
 			err = vmexport.WaitUntilVirtualMachineExportReady(virtClient, namespace, name)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should return error", func() {
+			_, err := vmExportClient.ExportV1beta1().VirtualMachineExports(namespace).Create(context.Background(),
+				&v1beta1.VirtualMachineExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Status: &v1beta1.VirtualMachineExportStatus{
+						Phase: v1beta1.Skipped,
+					},
+				},
+				metav1.CreateOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = vmexport.WaitUntilVirtualMachineExportReady(virtClient, namespace, name)
+			Expect(err).To(MatchError("vm export is in skipped phase"))
+		})
 	})
 
 	Describe("GetRawDiskUrlFromVolumes", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: when vmExport is in skipped phase, exit the disk uploader task

vm export cannot recover from skipped phase and thus it doesn't make sense to wait.

**Which issue(s) this PR fixes**:
Fixes: https://issues.redhat.com/browse/CNV-56960

**Release note**:

```release-note
fix: when vmExport is in skipped phase, exit the disk uploader task

```
