### PR TITLE
fix: test-with-reports makefile target

### DIFF
--- a/modules/disk-uploader/pkg/vmexport/vmexport_test.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport_test.go
@@ -4,23 +4,22 @@ import (
 	"context"
 	"os"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/golang/mock/gomock"
-
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-uploader/pkg/vmexport"
+	"github.com/kubevirt/kubevirt-tekton-tasks/modules/shared/pkg/log"
 	v1beta1 "kubevirt.io/api/export/v1beta1"
 	fakecdiclient "kubevirt.io/client-go/containerizeddataimporter/fake"
 	"kubevirt.io/client-go/kubecli"
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
-
-	"github.com/kubevirt/kubevirt-tekton-tasks/modules/disk-uploader/pkg/vmexport"
 )
 
 var _ = Describe("VMExport", func() {
@@ -95,6 +94,9 @@ var _ = Describe("VMExport", func() {
 
 	Describe("WaitUntilVirtualMachineExportReady", func() {
 		It("should return no error", func() {
+			//initialize logger, otherwise logging events inside fn panics
+			log.InitLogger(zap.InfoLevel)
+
 			_, err := vmExportClient.ExportV1beta1().VirtualMachineExports(namespace).Create(context.Background(),
 				&v1beta1.VirtualMachineExport{
 					ObjectMeta: metav1.ObjectMeta{

--- a/modules/wait-for-vmi-status/pkg/requirements/lookup_test.go
+++ b/modules/wait-for-vmi-status/pkg/requirements/lookup_test.go
@@ -25,9 +25,9 @@ var _ = Describe("Lookup", func() {
 		Entry("nil vm", nil, testSelector, labels.Set{}),
 		Entry("empty requirements", testobjects.NewTestFedoraCloudVM("fedora").Build(), "", labels.Set{}),
 		Entry("basic", testobjects.NewTestFedoraCloudVM("fedora").Build(), testSelector, labels.Set{
-			"metadata.name": "fedora",
-			"spec.running":  "false",
-			"metadata":      "{\"name\":\"fedora\",\"namespace\":\"default\",\"creationTimestamp\":null}",
+			"metadata.name":    "fedora",
+			"spec.runStrategy": "Halted",
+			"metadata":         "{\"name\":\"fedora\",\"namespace\":\"default\",\"creationTimestamp\":null}",
 		}),
 		Entry("with spaces", testobjects.NewTestFedoraCloudVM("fedora").Build(), "  metadata.name   ", labels.Set{
 			"metadata.name": "fedora",

--- a/modules/wait-for-vmi-status/pkg/requirements/requirements_suite_test.go
+++ b/modules/wait-for-vmi-status/pkg/requirements/requirements_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const testSelector = "metadata.name in (fedora, ubuntu), spec.running != true, invalid.path notin (1, 2, 3), metadata"
+const testSelector = "metadata.name in (fedora, ubuntu), spec.runStrategy != true, invalid.path notin (1, 2, 3), metadata"
 
 func TestLog(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/modules/wait-for-vmi-status/pkg/requirements/requirements_test.go
+++ b/modules/wait-for-vmi-status/pkg/requirements/requirements_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Reruirements", func() {
 				utilstest.GetRequirement("invalid.path", selection.NotIn, []string{"1", "2", "3"}),
 				utilstest.GetRequirement("metadata", selection.Exists, []string{}),
 				utilstest.GetRequirement("metadata.name", selection.In, []string{"fedora", "ubuntu"}),
-				utilstest.GetRequirement("spec.running", selection.NotEquals, []string{"true"}),
+				utilstest.GetRequirement("spec.runStrategy", selection.NotEquals, []string{"true"}),
 			}),
 			Entry("with spaces", "  metadata.name   ", labels.Requirements{
 				utilstest.GetRequirement("metadata.name", selection.Exists, []string{}),
@@ -50,7 +50,7 @@ var _ = Describe("Reruirements", func() {
 			Entry("vm and empty requirements", testobjects.NewTestFedoraCloudVM("fedora").Build(), labels.Requirements{}, true),
 			Entry("matches requirements", testobjects.NewTestFedoraCloudVM("fedora").Build(), labels.Requirements{
 				utilstest.GetRequirement("metadata.name", selection.In, []string{"fedora", "ubuntu"}),
-				utilstest.GetRequirement("spec.running", selection.NotEquals, []string{"true"}),
+				utilstest.GetRequirement("spec.runStrategy", selection.NotEquals, []string{"true"}),
 			}, true),
 			Entry("does not match requirements", testobjects.NewTestFedoraCloudVM("fedora").Build(), labels.Requirements{
 				utilstest.GetRequirement("metadata.name", selection.In, []string{"ubuntu", "arch"}),
@@ -59,7 +59,7 @@ var _ = Describe("Reruirements", func() {
 				utilstest.GetRequirement("invalid.path", selection.In, []string{"1", "2", "3"}),
 				utilstest.GetRequirement("metadata", selection.Exists, []string{}),
 				utilstest.GetRequirement("metadata.name", selection.In, []string{"ubuntu", "arch"}),
-				utilstest.GetRequirement("spec.running", selection.NotEquals, []string{"true"}),
+				utilstest.GetRequirement("spec.runStrategy", selection.NotEquals, []string{"true"}),
 			}, false),
 		)
 	})

--- a/scripts/test-with-reports.sh
+++ b/scripts/test-with-reports.sh
@@ -23,24 +23,22 @@ rm -rf "${TEST_OUT}" "${COVER_OUT}" "${JUNIT_XML}" "${COVERAGE_HTML}" "${FAKE_GO
 mkdir -p "${ARTIFACT_DIR}"
 
 visit "${REPO_DIR}/modules"
-  for MODULE_DIR in $(ls | grep -vE "^(tests)$"); do
+  for MODULE_DIR in */ ; do
     visit "$MODULE_DIR"
-      if [ -f go.mod ]; then
-        DIST_DIR=dist
-        mkdir -p ${DIST_DIR}
-        go test -v -coverprofile=${DIST_DIR}/coverage.out -covermode=atomic \
-           $(go list ./... | grep -v utilstest) | tee ${DIST_DIR}/test.out
-        CURRENT_RET_CODE=$?
-        if [ "${CURRENT_RET_CODE}" -ne 0 ]; then
-          RET_CODE=${CURRENT_RET_CODE}
-        fi
-        cat ${DIST_DIR}/test.out >> "${TEST_OUT}"
+      DIST_DIR=dist
+      mkdir -p ${DIST_DIR}
+      go test -v -coverprofile=${DIST_DIR}/coverage.out -covermode=atomic \
+        $(go list ./... | grep -v utilstest) | tee ${DIST_DIR}/test.out
+      CURRENT_RET_CODE=$?
+      if [ "${CURRENT_RET_CODE}" -ne 0 ]; then
+        RET_CODE=${CURRENT_RET_CODE}
+      fi
+      cat ${DIST_DIR}/test.out >> "${TEST_OUT}"
 
-        if [ -f "${COVER_OUT}" ]; then
-          sed "/^mode.*/d" dist/coverage.out >> "${COVER_OUT}" # remove first line with mode
-        else
-          cp ${DIST_DIR}/coverage.out "${COVER_OUT}"
-        fi
+      if [ -f "${COVER_OUT}" ]; then
+        sed "/^mode.*/d" dist/coverage.out >> "${COVER_OUT}" # remove first line with mode
+      else
+        cp ${DIST_DIR}/coverage.out "${COVER_OUT}"
       fi
     leave
   done


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: test-with-reports makefile target

the script was checking if module contains go.mod file and if not it skips the module. The go.mod files were removed and only one is kept in the root of the project. This PR removes the check for go.mod file and fixes failing unit tests.

**Release note**:
```release-note
NONE
```
