### PR TITLE
feat: add securityContext in task manifests

### DIFF
--- a/release/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/release/tasks/cleanup-vm/cleanup-vm.yaml
@@ -88,6 +88,13 @@ spec:
         - mountPath: /data/connectionsecret/
           name: connectionsecret
           readOnly: true
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: connectionsecret
       secret:

--- a/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -81,3 +81,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/release/tasks/disk-uploader/disk-uploader.yaml
+++ b/release/tasks/disk-uploader/disk-uploader.yaml
@@ -87,6 +87,13 @@ spec:
     volumeMounts:
       - mountPath: /tmp
         name: disk
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      seccompProfile:
+        type: RuntimeDefault
   volumes:
     - name: disk
       emptyDir: {}

--- a/release/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/release/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -68,6 +68,13 @@ spec:
           name: guestfsappliance
         - mountPath: /mnt/targetpvc/
           name: targetpvc
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: guestfsappliance
       emptyDir: {}

--- a/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -68,6 +68,13 @@ spec:
           name: guestfsappliance
         - mountPath: /mnt/targetpvc/
           name: targetpvc
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: guestfsappliance
       emptyDir: {}

--- a/release/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/release/tasks/execute-in-vm/execute-in-vm.yaml
@@ -69,6 +69,13 @@ spec:
         - mountPath: /data/connectionsecret/
           name: connectionsecret
           readOnly: true
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: connectionsecret
       secret:

--- a/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -76,3 +76,10 @@ spec:
           value: $(params.privateKeySecretNamespace)
         - name: ADDITIONAL_SSH_KEYGEN_OPTIONS
           value: $(params.additionalSSHKeygenOptions)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -97,3 +97,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -39,6 +39,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.24.0"
       script: |
         #!/bin/bash
@@ -87,6 +89,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "quay.io/kubevirt/tekton-tasks:v0.24.0"
       script: |
         #!/bin/bash
@@ -114,6 +118,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "quay.io/kubevirt/tekton-tasks-disk-virt:v0.24.0"
       script: |
         #!/bin/bash

--- a/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -53,3 +53,10 @@ spec:
           value: $(params.successCondition)
         - name: FAILURE_CONDITION
           value: $(params.failureCondition)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -81,3 +81,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/templates/disk-uploader/manifests/disk-uploader.yaml
+++ b/templates/disk-uploader/manifests/disk-uploader.yaml
@@ -87,6 +87,13 @@ spec:
     volumeMounts:
       - mountPath: /tmp
         name: disk
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - "ALL"
+      seccompProfile:
+        type: RuntimeDefault
   volumes:
     - name: disk
       emptyDir: {}

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -68,6 +68,13 @@ spec:
           name: guestfsappliance
         - mountPath: /mnt/targetpvc/
           name: targetpvc
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: guestfsappliance
       emptyDir: {}

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -68,6 +68,13 @@ spec:
           name: guestfsappliance
         - mountPath: /mnt/targetpvc/
           name: targetpvc
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: guestfsappliance
       emptyDir: {}

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -94,6 +94,13 @@ spec:
         - mountPath: /data/connectionsecret/
           name: connectionsecret
           readOnly: true
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
   volumes:
     - name: connectionsecret
       secret:

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -76,3 +76,10 @@ spec:
           value: $(params.privateKeySecretNamespace)
         - name: ADDITIONAL_SSH_KEYGEN_OPTIONS
           value: $(params.additionalSSHKeygenOptions)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -97,3 +97,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -39,6 +39,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "{{ extract_iso_image }}:{{ version }}"
       script: |
         #!/bin/bash
@@ -87,6 +89,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "{{ create_iso_image }}:{{ version }}"
       script: |
         #!/bin/bash
@@ -114,6 +118,8 @@ spec:
         capabilities:
           drop:
           - "ALL"
+        seccompProfile:
+          type: RuntimeDefault
       image: "{{ extract_iso_image }}:{{ version }}"
       script: |
         #!/bin/bash

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -53,3 +53,10 @@ spec:
           value: $(params.successCondition)
         - name: FAILURE_CONDITION
           value: $(params.failureCondition)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - "ALL"
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add securityContext in task manifests

The OCP4.19 requires security context to be part of the manifests

**Release note**:
```release-note
feat: add securityContext in task manifests
```
/hold 