### PR TITLE
feat: bump virtio win image version in installer pipeline

### DIFF
--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend, windows10-efi-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       name: autounattendConfigMapName
       type: string
-    - default: quay.io/kubevirt/virtio-container-disk:v1.2.0
+    - default: quay.io/kubevirt/virtio-container-disk:v1.5.0
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       name: virtioContainerDiskName
       type: string

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -55,7 +55,7 @@ spec:
       description: Name of the ConfigMap containing the sysprep configuration files (autounattend.xml, etc.). For example windows11-autounattend, windows10-efi-autounattend or windows2022-autounattend. It is possible to provide customize ConfigMaps created by the user too.
       name: autounattendConfigMapName
       type: string
-    - default: quay.io/kubevirt/virtio-container-disk:v1.2.0
+    - default: quay.io/kubevirt/virtio-container-disk:v1.5.0
       description: Reference to the containerdisk containing the virtio-win drivers ISO.
       name: virtioContainerDiskName
       type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: bump virtio win image version in installer pipeline
follow up - modify https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/tekton-tasks-periodics.yaml#L32

**Release note**:
```release-note
feat: bump virtio win image version in installer pipeline
```
