### PR TITLE
fix: use correct windows 2k25 drivers in installer pipeline

### DIFF
--- a/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -469,10 +469,10 @@ data:
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <DriverPaths>
             <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-              <Path>E:\viostor\2k22\amd64</Path>
+              <Path>E:\viostor\2k25\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-              <Path>E:\NetKVM\2k22\amd64</Path>
+              <Path>E:\NetKVM\2k25\amd64</Path>
             </PathAndCredentials>
           </DriverPaths>
         </component>

--- a/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -469,10 +469,10 @@ data:
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <DriverPaths>
             <PathAndCredentials wcm:action="add" wcm:keyValue="1">
-              <Path>E:\viostor\2k22\amd64</Path>
+              <Path>E:\viostor\2k25\amd64</Path>
             </PathAndCredentials>
             <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-              <Path>E:\NetKVM\2k22\amd64</Path>
+              <Path>E:\NetKVM\2k25\amd64</Path>
             </PathAndCredentials>
           </DriverPaths>
         </component>


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: use correct windows 2k25 drivers in installer pipeline

**Release note**:
```
fix: use correct windows 2k25 drivers in installer pipeline
```
