### PR TITLE
fix: update example windows customize configmap

### DIFF
--- a/automation/e2e-pipelines/test-files/windows11-dv.yaml
+++ b/automation/e2e-pipelines/test-files/windows11-dv.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   source:
     registry:
-      url: docker://quay.io/openshift-cnv/containerdisks:Win11_22H2_English_x64
+      url: docker://quay.io/openshift-cnv/containerdisks:Win11_24H2_English_x64
       secretRef: tekton-tasks-container-disk-puller
   storage:
     volumeMode: Filesystem

--- a/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -245,9 +245,17 @@ data:
           </AutoLogon>
           <FirstLogonCommands>
             <SynchronousCommand wcm:action="add">
+              <CommandLine>bcdedit /set device partition=C:</CommandLine>
+              <Order>1</Order>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
+              <CommandLine>bcdedit /set osdevice partition=C:</CommandLine>
+              <Order>2</Order>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
               <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoLogonCount /t REG_DWORD /d 0 /f</CommandLine>
               <RequiresUserInput>false</RequiresUserInput>
-              <Order>1</Order>
+              <Order>3</Order>
               <Description>Set AutoLogonCount to 0</Description>
             </SynchronousCommand>
           </FirstLogonCommands>

--- a/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -245,9 +245,17 @@ data:
           </AutoLogon>
           <FirstLogonCommands>
             <SynchronousCommand wcm:action="add">
+              <CommandLine>bcdedit /set device partition=C:</CommandLine>
+              <Order>1</Order>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
+              <CommandLine>bcdedit /set osdevice partition=C:</CommandLine>
+              <Order>2</Order>
+            </SynchronousCommand>
+            <SynchronousCommand wcm:action="add">
               <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoLogonCount /t REG_DWORD /d 0 /f</CommandLine>
               <RequiresUserInput>false</RequiresUserInput>
-              <Order>1</Order>
+              <Order>3</Order>
               <Description>Set AutoLogonCount to 0</Description>
             </SynchronousCommand>
           </FirstLogonCommands>


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: update example windows customize configmap

Latest Windows 11 24h2 contains bug, which is causing the VM to boot into BSOD. This is happening because, when VM is syspreped and bitlocker is enabled, bitlocker modifies bootloader parameters, which then forces VM to boot into BSOD. This PR is updating the Win11 unattend xml and adding commands which fixes the parameters for bootloader.

**Release note**:
```
NONE
```
