### PR TITLE
feat: add openshift.io/required-scc annotations to tasks

### DIFF
--- a/release/tasks/cleanup-vm/cleanup-vm.yaml
+++ b/release/tasks/cleanup-vm/cleanup-vm.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
+++ b/release/tasks/create-vm-from-manifest/create-vm-from-manifest.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/disk-uploader/disk-uploader.yaml
+++ b/release/tasks/disk-uploader/disk-uploader.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt, containerdisks

--- a/release/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/release/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/execute-in-vm/execute-in-vm.yaml
+++ b/release/tasks/execute-in-vm/execute-in-vm.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
+++ b/release/tasks/generate-ssh-keys/generate-ssh-keys.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/modify-data-object/modify-data-object.yaml
+++ b/release/tasks/modify-data-object/modify-data-object.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
+++ b/release/tasks/modify-windows-iso-file/modify-windows-iso-file.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
+++ b/release/tasks/wait-for-vmi-status/wait-for-vmi-status.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: pipeline-scc
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/scripts/cluster-test.sh
+++ b/scripts/cluster-test.sh
@@ -24,7 +24,32 @@ mkdir -p "${ARTIFACT_DIR}"
 
 kubectl get namespaces -o name | grep -Eq "^namespace/$DEPLOY_NAMESPACE$" || kubectl create namespace "$DEPLOY_NAMESPACE" > /dev/null
 
-
+# for purposes of disk-virt tests, we need to create SCC, which will allow pod to 
+# set FSgroup to uid 107
+oc apply -f - <<EOF
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: tekton-tasks-scc
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 107
+      max: 107
+users:
+- system:serviceaccount:${DEPLOY_NAMESPACE}:pipeline
+EOF
 pushd test || exit
   rm -rf dist
   mkdir dist
@@ -44,5 +69,5 @@ pushd test || exit
 
 popd
 
-
+oc delete scc tekton-tasks-scc
 exit "${RET_CODE}"

--- a/templates/create-vm-from-manifest/manifests/create-vm.yaml
+++ b/templates/create-vm-from-manifest/manifests/create-vm.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/disk-uploader/manifests/disk-uploader.yaml
+++ b/templates/disk-uploader/manifests/disk-uploader.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt, containerdisks

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/execute-in-vm/manifests/execute-in-vm.yaml
+++ b/templates/execute-in-vm/manifests/execute-in-vm.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
+++ b/templates/generate-ssh-keys/manifests/generate-ssh-keys.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/modify-data-object/manifests/modify-data-object.yaml
+++ b/templates/modify-data-object/manifests/modify-data-object.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
+++ b/templates/modify-windows-iso-file/manifests/modify-windows-iso-file.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: restricted-v2
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
+++ b/templates/wait-for-vmi-status/manifests/wait-for-vmi-status.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    openshift.io/required-scc: pipeline-scc
     tekton.dev/pipelines.minVersion: "0.43.0"
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt

--- a/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
+++ b/test/testconfigs/disk-virt-libguestfs-tasks-test-config.go
@@ -96,6 +96,9 @@ func (c *DiskVirtLibguestfsTestConfig) GetTaskRunWithName(nameSuffix string) *pi
 	var qemuUser int64 = 107
 	return &pipev1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "tekton-tasks-scc",
+			},
 			Name:      E2ETestsRandomName("taskrun-disk-" + string(c.TaskData.LibguestfsTaskType) + nameSuffix),
 			Namespace: c.deploymentNamespace,
 		},


### PR DESCRIPTION
Since OCP 4.19 this annotation is required to be present in pod definition.
This PR sets this annotation to use restricted-v2 SCC. However for purposes of the tests, we need to create our own SCC, which will allow to set FS group in pod to uid 107.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
feat: add openshift.io/required-scc annotations to tasks

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
