### PR TITLE
fix: failing e2e test

### DIFF
--- a/test/create_vm_from_manifest_test.go
+++ b/test/create_vm_from_manifest_test.go
@@ -175,8 +175,9 @@ var _ = Describe("Create VM from manifest", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// fill VM accordingly
-		expectedVM.Spec.Template.Spec.Domain.Machine = vm.Spec.Template.Spec.Domain.Machine // ignore Machine
-		expectedVM.Spec.Template.Spec.Architecture = vm.Spec.Template.Spec.Architecture     // ignore Architecture
+		expectedVM.Spec.Template.Spec.Domain.Machine = vm.Spec.Template.Spec.Domain.Machine   // ignore Machine
+		expectedVM.Spec.Template.Spec.Architecture = vm.Spec.Template.Spec.Architecture       // ignore Architecture
+		expectedVM.Spec.Template.Spec.Domain.Firmware = vm.Spec.Template.Spec.Domain.Firmware // ignore Firmware
 		expectedVM.Spec.Template.ObjectMeta.Labels["vm.kubevirt.io/name"] = vm.Spec.Template.ObjectMeta.Name
 
 		Expect(vm.Spec.Template.Spec).Should(Equal(expectedVM.Spec.Template.Spec))


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: failing e2e test

In azure clusters, the e2e test "VM is created from manifest properly" is failing, because created VM has populated spec.template.spec.domain.firmware struct, which is populated with random ID during creation
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
