### PR TITLE
add s390x support

### DIFF
--- a/build/Containerfile.DiskVirt
+++ b/build/Containerfile.DiskVirt
@@ -20,7 +20,7 @@ RUN task_names=("disk-virt-customize" "disk-virt-sysprep"); \
         CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -mod=vendor -o /out/${TASK_NAME} ./cmd/${TASK_NAME}; \
     done
 
-FROM --platform=linux/${TARGETARCH} quay.io/kubevirt/libguestfs-tools:v1.5.0
+FROM --platform=linux/${TARGETARCH} quay.io/kubevirt/libguestfs-tools:v1.6.0
 ENV USER_UID=1001 \
     USER_NAME=tekton-tasks-disk-virt \
     HOME=/home/${USER_NAME}

--- a/release/tasks/disk-virt-customize/disk-virt-customize.yaml
+++ b/release/tasks/disk-virt-customize/disk-virt-customize.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt customize"
-    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/platforms: "linux/amd64,linux/arm64,linux/s390x"
     artifacthub.io/maintainers: |
       - name: KubeVirt Tekton tasks maintainers
         email: kubevirt-tekton-tasks@redhat.com

--- a/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
+++ b/release/tasks/disk-virt-sysprep/disk-virt-sysprep.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "KubeVirt disk virt sysprep"
-    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/platforms: "linux/amd64,linux/arm64,linux/s390x"
     artifacthub.io/maintainers: |
       - name: KubeVirt Tekton tasks maintainers
         email: kubevirt-tekton-tasks@redhat.com

--- a/scripts/build-release-images.sh
+++ b/scripts/build-release-images.sh
@@ -30,4 +30,4 @@ IMAGE="${REGISTRY}/${REPOSITORY}/${IMAGE_NAME_AND_TAG}"
 # Remove any existing manifest and image
 podman manifest exists "$IMAGE" && podman manifest rm "${IMAGE}" || true
 podman image exists "$IMAGE" && podman rmi "${IMAGE}" || true
-podman build --platform=linux/amd64,linux/arm64 --manifest "${IMAGE}" -f "build/Containerfile.DiskVirt" .
+podman build --platform=linux/amd64,linux/arm64,linux/s390x --manifest "${IMAGE}" -f "build/Containerfile.DiskVirt" .

--- a/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
+++ b/templates/disk-virt-customize/manifests/disk-virt-customize.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
-    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/platforms: "linux/amd64,linux/arm64,linux/s390x"
     artifacthub.io/maintainers: |
       - name: {{ maintainer_name }}
         email: {{ maintainer_email }}

--- a/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
+++ b/templates/disk-virt-sysprep/manifests/disk-virt-sysprep.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/categories: Automation
     tekton.dev/tags: kubevirt
     tekton.dev/displayName: "{{ display_name_provider }} {{ nice_name }}"
-    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/platforms: "linux/amd64,linux/arm64,linux/s390x"
     artifacthub.io/maintainers: |
       - name: {{ maintainer_name }}
         email: {{ maintainer_email }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is follow up PR to enable tekton tasks multi-arch support. Now "libguestfs-tools:v1.6.0" supports multi-arch image, so update diskvirt releated images with s390x changes, which are missing in the initial multi arch PR. https://github.com/kubevirt/kubevirt-tekton-tasks/pull/698/files#r2003349293 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
