### PR TITLE
fix: e2e example pipeline tests

### DIFF
--- a/automation/e2e-pipelines/example-pipelines-test.sh
+++ b/automation/e2e-pipelines/example-pipelines-test.sh
@@ -58,6 +58,9 @@ fi
 echo "Deploying resources"
 ./automation/e2e-deploy-resources.sh
 
+#insert information about access modes and volume mode
+oc patch storageprofile ssd-csi --type=merge -p '{"spec": {"claimPropertySets": [{"accessModes": ["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
+
 # SECRET
 accessKeyId="/tmp/secrets/accessKeyId"
 secretKey="/tmp/secrets/secretKey"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: e2e example pipeline tests

The pipeline tests stoped working because of missing information in storageProfile. This commit adds patch command, which adds the missing information in ssd storageProfile.

**Release note**:
```release-note
NONE
```
