### PR TITLE
fix: Add BypassNRO registry key for Windows 11 OOBE automation

### DIFF
--- a/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -106,6 +106,15 @@ data:
         </component>
       </settings>
       <settings pass="specialize">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <RunSynchronous>
+            <RunSynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <Path>reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+              <Description>Bypass Windows 11 Network Requirement</Description>
+            </RunSynchronousCommand>
+          </RunSynchronous>
+        </component>
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <InputLocale>0409:00000409</InputLocale>
           <SystemLocale>en-US</SystemLocale>

--- a/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -106,6 +106,15 @@ data:
         </component>
       </settings>
       <settings pass="specialize">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+          <RunSynchronous>
+            <RunSynchronousCommand wcm:action="add">
+              <Order>1</Order>
+              <Path>reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+              <Description>Bypass Windows 11 Network Requirement</Description>
+            </RunSynchronousCommand>
+          </RunSynchronous>
+        </component>
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
           <InputLocale>0409:00000409</InputLocale>
           <SystemLocale>en-US</SystemLocale>


### PR DESCRIPTION
## Summary

Windows 11 requires network connectivity during OOBE by default. This causes the installation to hang at "Let's connect you to a network" screen when no network is available or in automated/unattended scenarios.

This PR adds a registry key in the `specialize` pass that bypasses this network requirement:

```
reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f
```

## Problem

When using the `windows-efi-installer` pipeline with the default `windows11-autounattend` ConfigMap, the Windows 11 VM gets stuck at the OOBE "Let's connect you to a network" screen, preventing fully automated installation.

## Solution

Add a `Microsoft-Windows-Deployment` component in the `specialize` pass with a `RunSynchronousCommand` that sets the `BypassNRO` registry key before OOBE runs.

## Testing

Tested on OpenShift cluster with the `windows-efi-installer` pipeline:
- Before: Windows 11 VM stuck at network setup screen
- After: Windows 11 VM boots directly to desktop with no manual intervention

## Files Changed

- `release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml`
- `templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml`

Made with [Cursor](https://cursor.com)