### PR TITLE
fix: switch VS Code to system-level installer in Windows customize pipeline

### DIFF
--- a/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -100,12 +100,13 @@ data:
     Set-NetIPInterface -InterfaceIndex $(Get-NetAdapter).ifIndex -NlMtuBytes 1300
 
     # Download VS Code
-    $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user"
-    $setupPath = "C:\VSCodeUserSetup-x64.exe"
+    $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64"
+    $setupPath = "C:\VSCodeSetup-x64.exe"
     Invoke-WebRequest -Uri $url -OutFile $setupPath
 
-    # vs code
-    Start-Process $setupPath -Wait -ArgumentList "/ACTION=INSTALL /VERYSILENT /MERGETASKS=!runcode"
+    Start-Process $setupPath -Wait -ArgumentList "/VERYSILENT /MERGETASKS=!runcode"
+
+    Get-AppxPackage *VisualStudioCode* | Remove-AppxPackage -ErrorAction SilentlyContinue
 
     # Rename cached unattend.xml to avoid it is picked up by sysprep
     mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.visualStudio.xml

--- a/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -100,12 +100,13 @@ data:
     Set-NetIPInterface -InterfaceIndex $(Get-NetAdapter).ifIndex -NlMtuBytes 1300
 
     # Download VS Code
-    $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user"
-    $setupPath = "C:\VSCodeUserSetup-x64.exe"
+    $url = "https://code.visualstudio.com/sha/download?build=stable&os=win32-x64"
+    $setupPath = "C:\VSCodeSetup-x64.exe"
     Invoke-WebRequest -Uri $url -OutFile $setupPath
 
-    # vs code
-    Start-Process $setupPath -Wait -ArgumentList "/ACTION=INSTALL /VERYSILENT /MERGETASKS=!runcode"
+    Start-Process $setupPath -Wait -ArgumentList "/VERYSILENT /MERGETASKS=!runcode"
+
+    Get-AppxPackage *VisualStudioCode* | Remove-AppxPackage -ErrorAction SilentlyContinue
 
     # Rename cached unattend.xml to avoid it is picked up by sysprep
     mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.visualStudio.xml


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the system installer (win32-x64) instead of the user installer (win32-x64-user) and add AppxPackage cleanup after installation.
Our CI is failing due to the error during syspreping in customize pipeline. This PR will fix it
**Special notes for your reviewer**:

**Release note**:
```release-note
fix: switch VS Code to system-level installer in Windows customize pipeline
```
