### PR TITLE
fix: Skip product key screen and preserve unattend.xml for OOBE automation

### DIFF
--- a/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -101,6 +101,7 @@ data:
             <AcceptEula>false</AcceptEula>
             <ProductKey>
               <Key/>
+              <WillShowUI>Never</WillShowUI>
             </ProductKey>
           </UserData>
         </component>
@@ -152,8 +153,57 @@ data:
     # Install qemu guest agent
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
-    # Rename cached unattend.xml to avoid it is picked up by sysprep
-    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+    # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
+    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
+    $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
+    $oobeXml += '  <settings pass="oobeSystem">' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <InputLocale>0409:00000409</InputLocale>' + "`n"
+    $oobeXml += '      <SystemLocale>en-US</SystemLocale>' + "`n"
+    $oobeXml += '      <UILanguage>en-US</UILanguage>' + "`n"
+    $oobeXml += '      <UserLocale>en-US</UserLocale>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <OOBE>' + "`n"
+    $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
+    $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '      </OOBE>' + "`n"
+    $oobeXml += '      <UserAccounts>' + "`n"
+    $oobeXml += '        <AdministratorPassword>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </AdministratorPassword>' + "`n"
+    $oobeXml += '        <LocalAccounts>' + "`n"
+    $oobeXml += '          <LocalAccount wcm:action="add">' + "`n"
+    $oobeXml += '            <Name>Administrator</Name>' + "`n"
+    $oobeXml += '            <Group>Administrators</Group>' + "`n"
+    $oobeXml += '            <Password>' + "`n"
+    $oobeXml += '              <Value></Value>' + "`n"
+    $oobeXml += '              <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '            </Password>' + "`n"
+    $oobeXml += '          </LocalAccount>' + "`n"
+    $oobeXml += '        </LocalAccounts>' + "`n"
+    $oobeXml += '      </UserAccounts>' + "`n"
+    $oobeXml += '      <AutoLogon>' + "`n"
+    $oobeXml += '        <Enabled>true</Enabled>' + "`n"
+    $oobeXml += '        <Username>Administrator</Username>' + "`n"
+    $oobeXml += '        <Password>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </Password>' + "`n"
+    $oobeXml += '      </AutoLogon>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '  </settings>' + "`n"
+    $oobeXml += '</unattend>'
+
+    # Write the OOBE-skip unattend to Sysprep folder
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
+
+    # Rename cached unattend.xml to avoid duplicate processing
+    Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
@@ -409,6 +459,7 @@ data:
             <AcceptEula>false</AcceptEula>
             <ProductKey>
               <Key/>
+              <WillShowUI>Never</WillShowUI>
             </ProductKey>
           </UserData>
         </component>
@@ -451,8 +502,57 @@ data:
     # Install qemu guest agent
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
-    # Rename cached unattend.xml to avoid it is picked up by sysprep
-    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+    # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
+    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
+    $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
+    $oobeXml += '  <settings pass="oobeSystem">' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <InputLocale>0409:00000409</InputLocale>' + "`n"
+    $oobeXml += '      <SystemLocale>en-US</SystemLocale>' + "`n"
+    $oobeXml += '      <UILanguage>en-US</UILanguage>' + "`n"
+    $oobeXml += '      <UserLocale>en-US</UserLocale>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <OOBE>' + "`n"
+    $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
+    $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '      </OOBE>' + "`n"
+    $oobeXml += '      <UserAccounts>' + "`n"
+    $oobeXml += '        <AdministratorPassword>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </AdministratorPassword>' + "`n"
+    $oobeXml += '        <LocalAccounts>' + "`n"
+    $oobeXml += '          <LocalAccount wcm:action="add">' + "`n"
+    $oobeXml += '            <Name>Administrator</Name>' + "`n"
+    $oobeXml += '            <Group>Administrators</Group>' + "`n"
+    $oobeXml += '            <Password>' + "`n"
+    $oobeXml += '              <Value></Value>' + "`n"
+    $oobeXml += '              <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '            </Password>' + "`n"
+    $oobeXml += '          </LocalAccount>' + "`n"
+    $oobeXml += '        </LocalAccounts>' + "`n"
+    $oobeXml += '      </UserAccounts>' + "`n"
+    $oobeXml += '      <AutoLogon>' + "`n"
+    $oobeXml += '        <Enabled>true</Enabled>' + "`n"
+    $oobeXml += '        <Username>Administrator</Username>' + "`n"
+    $oobeXml += '        <Password>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </Password>' + "`n"
+    $oobeXml += '      </AutoLogon>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '  </settings>' + "`n"
+    $oobeXml += '</unattend>'
+
+    # Write the OOBE-skip unattend to Sysprep folder
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
+
+    # Rename cached unattend.xml to avoid duplicate processing
+    Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")

--- a/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -154,7 +154,7 @@ data:
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
     # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
-    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    # This XML contains Microsoft-Windows-Shell-Setup with full OOBE skip settings for Windows 11
     $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
     $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
     $oobeXml += '  <settings pass="oobeSystem">' + "`n"
@@ -167,9 +167,15 @@ data:
     $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
     $oobeXml += '      <OOBE>' + "`n"
     $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideLocalAccountScreen>true</HideLocalAccountScreen>' + "`n"
+    $oobeXml += '        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>' + "`n"
     $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
     $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <NetworkLocation>Work</NetworkLocation>' + "`n"
     $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '        <SkipMachineOOBE>true</SkipMachineOOBE>' + "`n"
+    $oobeXml += '        <SkipUserOOBE>true</SkipUserOOBE>' + "`n"
+    $oobeXml += '        <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>' + "`n"
     $oobeXml += '      </OOBE>' + "`n"
     $oobeXml += '      <UserAccounts>' + "`n"
     $oobeXml += '        <AdministratorPassword>' + "`n"
@@ -199,11 +205,14 @@ data:
     $oobeXml += '  </settings>' + "`n"
     $oobeXml += '</unattend>'
 
-    # Write the OOBE-skip unattend to Sysprep folder
-    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
-
-    # Rename cached unattend.xml to avoid duplicate processing
+    # Rename original unattend.xml (used for installation) to avoid conflict
     Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
+
+    # Write the OOBE-skip unattend to Panther folder where Windows looks during OOBE
+    $oobeXml | Out-File -FilePath "C:\Windows\Panther\unattend.xml" -Encoding UTF8 -Force
+    
+    # Also write to Sysprep folder as backup location
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
@@ -503,7 +512,7 @@ data:
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
     # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
-    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    # This XML contains Microsoft-Windows-Shell-Setup with full OOBE skip settings for Windows 10
     $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
     $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
     $oobeXml += '  <settings pass="oobeSystem">' + "`n"
@@ -516,9 +525,15 @@ data:
     $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
     $oobeXml += '      <OOBE>' + "`n"
     $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideLocalAccountScreen>true</HideLocalAccountScreen>' + "`n"
+    $oobeXml += '        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>' + "`n"
     $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
     $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <NetworkLocation>Work</NetworkLocation>' + "`n"
     $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '        <SkipMachineOOBE>true</SkipMachineOOBE>' + "`n"
+    $oobeXml += '        <SkipUserOOBE>true</SkipUserOOBE>' + "`n"
+    $oobeXml += '        <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>' + "`n"
     $oobeXml += '      </OOBE>' + "`n"
     $oobeXml += '      <UserAccounts>' + "`n"
     $oobeXml += '        <AdministratorPassword>' + "`n"
@@ -548,11 +563,14 @@ data:
     $oobeXml += '  </settings>' + "`n"
     $oobeXml += '</unattend>'
 
-    # Write the OOBE-skip unattend to Sysprep folder
-    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
-
-    # Rename cached unattend.xml to avoid duplicate processing
+    # Rename original unattend.xml (used for installation) to avoid conflict
     Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
+
+    # Write the OOBE-skip unattend to Panther folder where Windows looks during OOBE
+    $oobeXml | Out-File -FilePath "C:\Windows\Panther\unattend.xml" -Encoding UTF8 -Force
+    
+    # Also write to Sysprep folder as backup location
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")

--- a/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -101,6 +101,7 @@ data:
             <AcceptEula>false</AcceptEula>
             <ProductKey>
               <Key/>
+              <WillShowUI>Never</WillShowUI>
             </ProductKey>
           </UserData>
         </component>
@@ -152,8 +153,57 @@ data:
     # Install qemu guest agent
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
-    # Rename cached unattend.xml to avoid it is picked up by sysprep
-    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+    # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
+    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
+    $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
+    $oobeXml += '  <settings pass="oobeSystem">' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <InputLocale>0409:00000409</InputLocale>' + "`n"
+    $oobeXml += '      <SystemLocale>en-US</SystemLocale>' + "`n"
+    $oobeXml += '      <UILanguage>en-US</UILanguage>' + "`n"
+    $oobeXml += '      <UserLocale>en-US</UserLocale>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <OOBE>' + "`n"
+    $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
+    $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '      </OOBE>' + "`n"
+    $oobeXml += '      <UserAccounts>' + "`n"
+    $oobeXml += '        <AdministratorPassword>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </AdministratorPassword>' + "`n"
+    $oobeXml += '        <LocalAccounts>' + "`n"
+    $oobeXml += '          <LocalAccount wcm:action="add">' + "`n"
+    $oobeXml += '            <Name>Administrator</Name>' + "`n"
+    $oobeXml += '            <Group>Administrators</Group>' + "`n"
+    $oobeXml += '            <Password>' + "`n"
+    $oobeXml += '              <Value></Value>' + "`n"
+    $oobeXml += '              <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '            </Password>' + "`n"
+    $oobeXml += '          </LocalAccount>' + "`n"
+    $oobeXml += '        </LocalAccounts>' + "`n"
+    $oobeXml += '      </UserAccounts>' + "`n"
+    $oobeXml += '      <AutoLogon>' + "`n"
+    $oobeXml += '        <Enabled>true</Enabled>' + "`n"
+    $oobeXml += '        <Username>Administrator</Username>' + "`n"
+    $oobeXml += '        <Password>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </Password>' + "`n"
+    $oobeXml += '      </AutoLogon>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '  </settings>' + "`n"
+    $oobeXml += '</unattend>'
+
+    # Write the OOBE-skip unattend to Sysprep folder
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
+
+    # Rename cached unattend.xml to avoid duplicate processing
+    Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
@@ -409,6 +459,7 @@ data:
             <AcceptEula>false</AcceptEula>
             <ProductKey>
               <Key/>
+              <WillShowUI>Never</WillShowUI>
             </ProductKey>
           </UserData>
         </component>
@@ -451,8 +502,57 @@ data:
     # Install qemu guest agent
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
-    # Rename cached unattend.xml to avoid it is picked up by sysprep
-    mv C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml
+    # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
+    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
+    $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
+    $oobeXml += '  <settings pass="oobeSystem">' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <InputLocale>0409:00000409</InputLocale>' + "`n"
+    $oobeXml += '      <SystemLocale>en-US</SystemLocale>' + "`n"
+    $oobeXml += '      <UILanguage>en-US</UILanguage>' + "`n"
+    $oobeXml += '      <UserLocale>en-US</UserLocale>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
+    $oobeXml += '      <OOBE>' + "`n"
+    $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
+    $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '      </OOBE>' + "`n"
+    $oobeXml += '      <UserAccounts>' + "`n"
+    $oobeXml += '        <AdministratorPassword>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </AdministratorPassword>' + "`n"
+    $oobeXml += '        <LocalAccounts>' + "`n"
+    $oobeXml += '          <LocalAccount wcm:action="add">' + "`n"
+    $oobeXml += '            <Name>Administrator</Name>' + "`n"
+    $oobeXml += '            <Group>Administrators</Group>' + "`n"
+    $oobeXml += '            <Password>' + "`n"
+    $oobeXml += '              <Value></Value>' + "`n"
+    $oobeXml += '              <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '            </Password>' + "`n"
+    $oobeXml += '          </LocalAccount>' + "`n"
+    $oobeXml += '        </LocalAccounts>' + "`n"
+    $oobeXml += '      </UserAccounts>' + "`n"
+    $oobeXml += '      <AutoLogon>' + "`n"
+    $oobeXml += '        <Enabled>true</Enabled>' + "`n"
+    $oobeXml += '        <Username>Administrator</Username>' + "`n"
+    $oobeXml += '        <Password>' + "`n"
+    $oobeXml += '          <Value></Value>' + "`n"
+    $oobeXml += '          <PlainText>true</PlainText>' + "`n"
+    $oobeXml += '        </Password>' + "`n"
+    $oobeXml += '      </AutoLogon>' + "`n"
+    $oobeXml += '    </component>' + "`n"
+    $oobeXml += '  </settings>' + "`n"
+    $oobeXml += '</unattend>'
+
+    # Write the OOBE-skip unattend to Sysprep folder
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
+
+    # Rename cached unattend.xml to avoid duplicate processing
+    Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")

--- a/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
+++ b/templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml
@@ -154,7 +154,7 @@ data:
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
     # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
-    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    # This XML contains Microsoft-Windows-Shell-Setup with full OOBE skip settings for Windows 11
     $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
     $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
     $oobeXml += '  <settings pass="oobeSystem">' + "`n"
@@ -167,9 +167,15 @@ data:
     $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
     $oobeXml += '      <OOBE>' + "`n"
     $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideLocalAccountScreen>true</HideLocalAccountScreen>' + "`n"
+    $oobeXml += '        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>' + "`n"
     $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
     $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <NetworkLocation>Work</NetworkLocation>' + "`n"
     $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '        <SkipMachineOOBE>true</SkipMachineOOBE>' + "`n"
+    $oobeXml += '        <SkipUserOOBE>true</SkipUserOOBE>' + "`n"
+    $oobeXml += '        <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>' + "`n"
     $oobeXml += '      </OOBE>' + "`n"
     $oobeXml += '      <UserAccounts>' + "`n"
     $oobeXml += '        <AdministratorPassword>' + "`n"
@@ -199,11 +205,14 @@ data:
     $oobeXml += '  </settings>' + "`n"
     $oobeXml += '</unattend>'
 
-    # Write the OOBE-skip unattend to Sysprep folder
-    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
-
-    # Rename cached unattend.xml to avoid duplicate processing
+    # Rename original unattend.xml (used for installation) to avoid conflict
     Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
+
+    # Write the OOBE-skip unattend to Panther folder where Windows looks during OOBE
+    $oobeXml | Out-File -FilePath "C:\Windows\Panther\unattend.xml" -Encoding UTF8 -Force
+    
+    # Also write to Sysprep folder as backup location
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")
@@ -503,7 +512,7 @@ data:
     Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
 
     # Create a minimal unattend.xml for Sysprep folder to skip OOBE after cloning
-    # This XML contains Microsoft-Windows-Shell-Setup with OOBE skip settings
+    # This XML contains Microsoft-Windows-Shell-Setup with full OOBE skip settings for Windows 10
     $oobeXml = '<?xml version="1.0" encoding="utf-8"?>' + "`n"
     $oobeXml += '<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">' + "`n"
     $oobeXml += '  <settings pass="oobeSystem">' + "`n"
@@ -516,9 +525,15 @@ data:
     $oobeXml += '    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">' + "`n"
     $oobeXml += '      <OOBE>' + "`n"
     $oobeXml += '        <HideEULAPage>true</HideEULAPage>' + "`n"
+    $oobeXml += '        <HideLocalAccountScreen>true</HideLocalAccountScreen>' + "`n"
+    $oobeXml += '        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>' + "`n"
     $oobeXml += '        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>' + "`n"
     $oobeXml += '        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>' + "`n"
+    $oobeXml += '        <NetworkLocation>Work</NetworkLocation>' + "`n"
     $oobeXml += '        <ProtectYourPC>3</ProtectYourPC>' + "`n"
+    $oobeXml += '        <SkipMachineOOBE>true</SkipMachineOOBE>' + "`n"
+    $oobeXml += '        <SkipUserOOBE>true</SkipUserOOBE>' + "`n"
+    $oobeXml += '        <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>' + "`n"
     $oobeXml += '      </OOBE>' + "`n"
     $oobeXml += '      <UserAccounts>' + "`n"
     $oobeXml += '        <AdministratorPassword>' + "`n"
@@ -548,11 +563,14 @@ data:
     $oobeXml += '  </settings>' + "`n"
     $oobeXml += '</unattend>'
 
-    # Write the OOBE-skip unattend to Sysprep folder
-    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
-
-    # Rename cached unattend.xml to avoid duplicate processing
+    # Rename original unattend.xml (used for installation) to avoid conflict
     Rename-Item C:\Windows\Panther\unattend.xml C:\Windows\Panther\unattend.install.xml -Force -ErrorAction SilentlyContinue
+
+    # Write the OOBE-skip unattend to Panther folder where Windows looks during OOBE
+    $oobeXml | Out-File -FilePath "C:\Windows\Panther\unattend.xml" -Encoding UTF8 -Force
+    
+    # Also write to Sysprep folder as backup location
+    $oobeXml | Out-File -FilePath "C:\Windows\System32\Sysprep\unattend.xml" -Encoding UTF8 -Force
 
     # Eject CD, to avoid that the unattend.xml on the CD is picked up by sysprep
     (New-Object -COMObject Shell.Application).NameSpace(17).ParseName("F:").InvokeVerb("Eject")


### PR DESCRIPTION
## Summary

This PR improves Windows 10/11 golden image automation by creating a proper `unattend.xml` with OOBE skip settings for cloned VMs.

## Problem

When using the `windows-efi-installer` pipeline to create golden images:
1. Product key screen appeared during installation (fixed by `WillShowUI: Never`)
2. **VMs cloned from the golden image showed OOBE screens** (country, keyboard, privacy settings)

The previous approach of copying the original `unattend.xml` to the Sysprep folder didn't work because the original file only has a `<Reseal><Mode>Audit</Mode>` in the `oobeSystem` pass - it lacks the `Microsoft-Windows-Shell-Setup` component with actual OOBE skip settings.

## Solution

Instead of copying the original `unattend.xml`, the `post-install.ps1` now **creates a new minimal unattend.xml** specifically for post-sysprep OOBE skip:

```xml
<settings pass="oobeSystem">
  <component name="Microsoft-Windows-Shell-Setup" ...>
    <OOBE>
      <HideEULAPage>true</HideEULAPage>
      <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
      <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
      <ProtectYourPC>3</ProtectYourPC>
    </OOBE>
    <UserAccounts>
      <!-- Local Administrator account with empty password -->
    </UserAccounts>
    <AutoLogon>
      <!-- Auto-login as Administrator -->
    </AutoLogon>
  </component>
</settings>
```

This ensures cloned VMs:
- Skip all OOBE screens (region, keyboard, privacy, etc.)
- Boot directly to desktop
- Auto-login as Administrator
- Have the QEMU guest agent running

## Testing

- **Before**: Cloned VMs showed OOBE "Is this the right country or region?" screen
- **After**: Cloned VMs boot directly to Windows desktop with auto-login

## Files Changed

- `templates-pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml`
- `release/pipelines/windows-efi-installer/configmaps/windows-efi-installer-configmaps.yaml`

Updated ConfigMaps:
- `windows11-autounattend`
- `windows10-efi-autounattend`

## Related

Follow-up to #845 which added BypassNRO registry key for network requirement bypass.

```release-note
fix: Windows 10/11 golden images now boot directly to desktop after cloning (skip OOBE)
```