### PR TITLE
fix(pipelines): remove BitLocker fix from windows11-unattend ConfigMap

### DIFF
--- a/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/release/pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -245,36 +245,12 @@ data:
           </AutoLogon>
           <FirstLogonCommands>
             <SynchronousCommand wcm:action="add">
-              <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile F:\post-update.ps1</CommandLine>
-              <Order>1</Order>
-            </SynchronousCommand>
-            <SynchronousCommand wcm:action="add">
               <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoLogonCount /t REG_DWORD /d 0 /f</CommandLine>
               <RequiresUserInput>false</RequiresUserInput>
-              <Order>2</Order>
+              <Order>1</Order>
               <Description>Set AutoLogonCount to 0</Description>
             </SynchronousCommand>
           </FirstLogonCommands>
         </component>
       </settings>
     </unattend>
-  post-update.ps1: |
-    bcdedit /set '{current}' device partition=C:
-    bcdedit /set '{current}' osdevice partition=C:
-    
-    $bcdOutput = bcdedit /enum all | Out-String
-
-    $pattern = @"
-    Resume from Hibernate
-    ---------------------
-    identifier\s+({[0-9a-fA-F-]+})
-    "@
-
-    if ($bcdOutput -match $pattern) {
-        $identifier = $Matches[1]
-        bcdedit /set $identifier device partition=C:
-    } else {
-        Write-Output "Identifier for 'Resume from Hibernate' not found."
-    }
-
-    bcdedit /set '{memdiag}' device partition=\Device\HarddiskVolume1

--- a/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
+++ b/templates-pipelines/windows-customize/configmaps/windows-customize-configmaps.yaml
@@ -245,36 +245,12 @@ data:
           </AutoLogon>
           <FirstLogonCommands>
             <SynchronousCommand wcm:action="add">
-              <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile F:\post-update.ps1</CommandLine>
-              <Order>1</Order>
-            </SynchronousCommand>
-            <SynchronousCommand wcm:action="add">
               <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoLogonCount /t REG_DWORD /d 0 /f</CommandLine>
               <RequiresUserInput>false</RequiresUserInput>
-              <Order>2</Order>
+              <Order>1</Order>
               <Description>Set AutoLogonCount to 0</Description>
             </SynchronousCommand>
           </FirstLogonCommands>
         </component>
       </settings>
     </unattend>
-  post-update.ps1: |
-    bcdedit /set '{current}' device partition=C:
-    bcdedit /set '{current}' osdevice partition=C:
-    
-    $bcdOutput = bcdedit /enum all | Out-String
-
-    $pattern = @"
-    Resume from Hibernate
-    ---------------------
-    identifier\s+({[0-9a-fA-F-]+})
-    "@
-
-    if ($bcdOutput -match $pattern) {
-        $identifier = $Matches[1]
-        bcdedit /set $identifier device partition=C:
-    } else {
-        Write-Output "Identifier for 'Resume from Hibernate' not found."
-    }
-
-    bcdedit /set '{memdiag}' device partition=\Device\HarddiskVolume1


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the post-update.ps1 script and its associated FirstLogonCommand from the windows11-unattend ConfigMap. The bcdedit commands that fixed BitLocker partition assignments are no longer needed.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: [CNV-82681](https://redhat.atlassian.net/browse/CNV-82681)

**Special notes for your reviewer**:

**Release note**:
```release-note
fix(pipelines): remove BitLocker fix from windows11-unattend ConfigMap
```
