### PR TITLE
test: fix s390x disk-virt tests by reverting to centos-stream:9-latest

### DIFF
--- a/test/disk_virt_libguestfs_tasks_test.go
+++ b/test/disk_virt_libguestfs_tasks_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Run disk virt-customize / virt-sysprep", func() {
 				TaskData: testconfigs.DiskVirtLibguestfsTaskData{
 					Datavolume: datavolume.NewBlankDataVolume("basic-functionality").
 						WithSize(15, resource.Giga).
-						WithRegistrySource("docker://quay.io/containerdisks/opensuse-leap:15.6").
+						WithRegistrySource("docker://quay.io/containerdisks/centos-stream:9-latest").
 						Build(),
 					Commands:           customizeCommand,
 					LibguestfsTaskType: taskType,

--- a/test/pipelines_test.go
+++ b/test/pipelines_test.go
@@ -64,7 +64,7 @@ spec:
     - ReadWriteOnce
   source:
     registry:
-      url: "docker://quay.io/containerdisks/opensuse-leap:15.6"
+      url: "docker://quay.io/containerdisks/centos-stream:9-latest"
 											`,
 									},
 								},


### PR DESCRIPTION
## Summary

Fixes #883

PR #783 changed the container disk image from `centos-stream:9-latest`
to `opensuse-leap:15.6` to reduce import time. However, `opensuse-leap:15.6`
only has `amd64` and `arm64` manifests — it has **no s390x variant** —
causing all `disk-virt-customize`, `disk-virt-sysprep`, and pipeline tests
to fail on s390x clusters with: 
Error retrieving image: choosing image instance: no image found in manifest list for architecture "s390x"



## What was tried

opensuse-tumbleweed:1.0.0 was considered as a replacement since it has an s390x manifest, however it was also found to be incompatible — the virt-customize and virt-sysprep tools fail with:
  "no operating systems were found in the guest image"
This is because the tumbleweed s390x cloud image uses a btrfs root filesystem with subvolume layout and an s390x-specific disk structure that the RHEL-based libguestfs appliance in the task container cannot inspect or detect as a valid OS.
Reverting to centos-stream:9-latest which:
- Has amd64, arm64, and s390x manifests
- Uses a standard xfs/ext4 filesystem detectable by libguestfs
- Is confirmed working end-to-end on s390x (virt-customize passes) Fixes #883

## Fix

Revert to `quay.io/containerdisks/centos-stream:9-latest` which supports
`amd64`, `arm64`, and `s390x` and is confirmed working end-to-end:








