### PR TITLE
feat(windows-efi-installer): add baseDvSize param for base DataVolume

### DIFF
--- a/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
+++ b/release/pipelines/windows-efi-installer/windows-efi-installer.yaml
@@ -63,6 +63,10 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
+    - default: 20Gi
+      description: Size of the base DataVolume which is created.
+      name: baseDvSize
+      type: string
     - default: win11
       description: Name of Windows ISO datavolume
       name: isoDVName
@@ -192,7 +196,7 @@ spec:
               storage:
                 resources:
                   requests:
-                    storage: 20Gi
+                    storage: $(params.baseDvSize)
               source:
                 blank: {}
         - name: waitForSuccess

--- a/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
+++ b/templates-pipelines/windows-efi-installer/manifests/windows-efi-installer.yaml
@@ -63,6 +63,10 @@ spec:
       description: Name of the base DataVolume which is created. Pre-installed Windows VMs can be created from this DataVolume.
       name: baseDvName
       type: string
+    - default: 20Gi
+      description: Size of the base DataVolume which is created.
+      name: baseDvSize
+      type: string
     - default: win11
       description: Name of Windows ISO datavolume
       name: isoDVName
@@ -211,7 +215,7 @@ spec:
               storage:
                 resources:
                   requests:
-                    storage: 20Gi
+                    storage: $(params.baseDvSize)
               source:
                 blank: {}
         - name: waitForSuccess


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an optional baseDvSize pipeline parameter (default 20Gi) so the create-vm-root-disk DataVolume size can be overridden per PipelineRun instead of being hardcoded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #904 

**Special notes for your reviewer**:

**Release note**:
```release-note
feat(windows-efi-installer): add baseDvSize param for base DataVolume
```
