### PR TITLE
fix(disk-uploader): increase image push retry backoff

### DIFF
--- a/modules/disk-uploader/pkg/image/image.go
+++ b/modules/disk-uploader/pkg/image/image.go
@@ -90,6 +90,13 @@ func Push(image v1.Image, imageDestination string, pushTimeout int, auth *authn.
 		remote.WithAuth(auth),
 		remote.WithContext(ctx),
 		remote.WithProgress(progressChan),
+		remote.WithRetryBackoff(remote.Backoff{
+			Duration: 2 * time.Second,
+			Factor:   2.0,
+			Jitter:   0.1,
+			Steps:    5,
+			Cap:      60 * time.Second,
+		}),
 	)
 
 	<-done


### PR DESCRIPTION
**What this PR does / why we need it**:
  Increases the image push retry backoff in the disk-uploader to improve resilience against transient server-side errors (e.g. Azure Container Registry
  `GENERIC_STORAGE_ERROR`). The default go-containerregistry retry (3 attempts: ~1s, ~3s delays) is replaced with a wider configuration (5 attempts:
  2s, 4s, 8s, 16s, 32s, capped at 60s).

  **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets
  merged)*:
  Fixes #908

  **Special notes for your reviewer**:
  The change is a single addition of `remote.WithRetryBackoff(...)` to the existing `remote.Write` call. No new dependencies or API changes.

  **Release note**:
  ```release-note
  Increased disk-uploader image push retry backoff (5 attempts, 2s-60s exponential backoff) to improve resilience against transient registry errors.
  ```
