### PR TITLE
feat(disk-uploader): delete VirtualMachineExport after use

### DIFF
--- a/cmd/disk-uploader/main.go
+++ b/cmd/disk-uploader/main.go
@@ -86,6 +86,12 @@ func run(opts parse.CLIOptions, k8sClient kubernetes.Interface, virtClient kubec
 		return "", err
 	}
 
+	log.Logger().Info("Deleting VirtualMachineExport object...", zap.String("namespace", vmExport.Namespace), zap.String("name", vmExport.Name))
+
+	if err := vmexport.DeleteVirtualMachineExport(virtClient, namespace, vmExport.Name); err != nil {
+		log.Logger().Warn("Failed to delete VirtualMachineExport", zap.String("namespace", vmExport.Namespace), zap.String("name", vmExport.Name), zap.Error(err))
+	}
+
 	log.Logger().Info("Building a new container image...")
 
 	labels, err := vmexport.GetLabelsFromExportSource(virtClient, kind, namespace, name, volumeName)

--- a/modules/disk-uploader/pkg/vmexport/vmexport.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport.go
@@ -51,6 +51,10 @@ func CreateVirtualMachineExport(virtClient kubecli.KubevirtClient, exportSourceK
 	return virtClient.VirtualMachineExport(exportSourceNamespace).Create(context.Background(), v1VmExport, metav1.CreateOptions{})
 }
 
+func DeleteVirtualMachineExport(virtClient kubecli.KubevirtClient, namespace, name string) error {
+	return virtClient.VirtualMachineExport(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
 func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, namespace, name string) error {
 	pollInterval := 60 * time.Second
 	pollTimeout := 3600 * time.Second

--- a/modules/disk-uploader/pkg/vmexport/vmexport.go
+++ b/modules/disk-uploader/pkg/vmexport/vmexport.go
@@ -52,7 +52,11 @@ func CreateVirtualMachineExport(virtClient kubecli.KubevirtClient, exportSourceK
 }
 
 func DeleteVirtualMachineExport(virtClient kubecli.KubevirtClient, namespace, name string) error {
-	return virtClient.VirtualMachineExport(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err := virtClient.VirtualMachineExport(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 func WaitUntilVirtualMachineExportReady(client kubecli.KubevirtClient, namespace, name string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
disk-uploader creates a VirtualMachineExport object (and its associated virt-export-* pod) to download a VM's disk image, then never deletes it - cleanup is left to the VirtualMachineExport after a 2hr TTL deadline. This PR explicitly deletes the VirtualMachineExport object once the disk download completes, rather than relying solely on it to timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #909 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
feat(disk-uploader): delete VirtualMachineExport after use
```
