### PR TITLE
fix(wait-for-vmi-status): use stable Running phase in e2e test

### DIFF
--- a/test/wait_for_vmi_status_test.go
+++ b/test/wait_for_vmi_status_test.go
@@ -119,7 +119,8 @@ var _ = Describe("Wait for VMI Status", func() {
 			},
 			TaskData: testconfigs.WaitForVMIStatusTaskData{
 				VM:               testobjects.NewTestAlpineVM("fulfills-success-condition-in-same-ns").Build(),
-				SuccessCondition: "status.phase == Scheduled",
+				SuccessCondition: "status.phase == Running",
+				FailureCondition: "status.phase == Failed",
 				ShouldStartVM:    true,
 			},
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace transient "Scheduled" phase with stable "Running" phase in the "fulfills success condition in the same namespace as deploy" test to eliminate race condition causing consistent timeouts.

Ref: https://redhat.atlassian.net/browse/CNV-93327

Assisted by Claude Opus 4.6 (Anthropic)
**Which issue(s) this PR fixes**:
Fixes https://redhat.atlassian.net/browse/CNV-93327

**Special notes for your reviewer**:

**Release note**:
```release-note
fix(wait-for-vmi-status): use stable Running phase in e2e test
```
