### PR TITLE
fix(test): eliminate race condition in WaitForTaskRunState log capture

### DIFF
--- a/test/tekton/taskrun.go
+++ b/test/tekton/taskrun.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kubevirt/kubevirt-tekton-tasks/test/constants"
 	"github.com/kubevirt/kubevirt-tekton-tasks/test/framework/clients"
-	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	pipev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	tkntest "github.com/tektoncd/pipeline/test"
@@ -21,33 +20,12 @@ import (
 )
 
 func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeout time.Duration, inState tkntest.ConditionAccessorFn) (*pipev1.TaskRun, string) {
-	isCapturing := false
-	logs := make(chan string, 1)
 	var taskRun *pipev1.TaskRun
 	err := wait.PollImmediate(constants.PollInterval, timeout, func() (bool, error) {
 		var err error
 		taskRun, err = clients.TknClient.TaskRuns(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return true, err
-		}
-
-		if taskRun.Status.PodName != "" && !isCapturing {
-			req := clients.CoreV1Client.Pods(taskRun.Namespace).GetLogs(taskRun.Status.PodName, &v1.PodLogOptions{
-				Follow: true,
-			})
-
-			podLogs, err := req.Stream(context.Background())
-			if err == nil {
-				isCapturing = true
-				go func() {
-					defer podLogs.Close()
-					defer GinkgoRecover()
-
-					result, err := ioutil.ReadAll(podLogs)
-					logs <- string(result)
-					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-				}()
-			}
 		}
 		return inState(&taskRun.Status)
 	})
@@ -56,11 +34,7 @@ func WaitForTaskRunState(clients *clients.Clients, namespace, name string, timeo
 	}
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-	if isCapturing {
-		return taskRun, <-logs
-	}
-
-	return taskRun, ""
+	return taskRun, getTaskRunLogs(clients.CoreV1Client, taskRun)
 }
 
 func PrintTaskRunDebugInfo(clients *clients.Clients, taskRunNamespace, taskRunName string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the Follow:true streaming goroutine from the poll loop and retrieve logs after the TaskRun reaches the desired state instead. The streaming approach raced with fast-completing pods — if the pod terminated before Stream() connected, logs were silently lost.

Resolves: [CNV-92714](https://redhat.atlassian.net/browse/CNV-92714)
Assisted-by: Claude (claude-opus-4-6)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [CNV-92714](https://redhat.atlassian.net/browse/CNV-92714)

**Special notes for your reviewer**:

**Release note**:
```release-note
fix(test): eliminate race condition in WaitForTaskRunState log capture
```
